### PR TITLE
fix: airdrop duplicate msg

### DIFF
--- a/src/commands/defi/airdrop.ts
+++ b/src/commands/defi/airdrop.ts
@@ -216,8 +216,10 @@ export async function enterAirdrop(
         }),
       ],
     })
-    if (participants.length === +maxEntries)
+    if (participants.length === +maxEntries) {
       airdropCache.emit("expired", cacheKey, participants)
+      airdropCache.del(cacheKey)
+    }
   }
 }
 


### PR DESCRIPTION
**What does this PR do?**

-   [x] airdrop duplicate msg ( when call emit expire, node cache execute the function and when node expire by ttl it execute again and create duplicate content in msg )


**Media (Loom or gif)**
Before
<img width="577" alt="Screenshot 2022-11-07 at 14 28 48" src="https://user-images.githubusercontent.com/49946656/200250839-be491ed8-0d25-4128-9024-f58d2dc51bbe.png">

After
<img width="553" alt="Screenshot 2022-11-07 at 14 31 14" src="https://user-images.githubusercontent.com/49946656/200251277-f55b33fb-ce90-4be6-9db5-2a27ddb811e9.png">

