### PR TITLE
fix: include expansion in twitter

### DIFF
--- a/src/utils/TwitterStream.ts
+++ b/src/utils/TwitterStream.ts
@@ -189,7 +189,7 @@ class TwitterStream extends InmemoryStorage {
   private async watchStream() {
     try {
       const stream = twitter.tweets.searchStream({
-        expansions: ["author_id"],
+        expansions: ["author_id", "entities.mentions.username"],
       })
       for await (const tweet of stream) {
         this.handle(tweet)


### PR DESCRIPTION
**What does this PR do?**

-   [x] Add expansion of mentions (otherwise the property will be undefined)
