### PR TITLE
fix: toggle chart render and add emoji

### DIFF
--- a/src/commands/community/nft/ticker.ts
+++ b/src/commands/community/nft/ticker.ts
@@ -53,7 +53,7 @@ function buildSwitchViewActionRow(
     days?: number
   }
 ) {
-  const { collectionAddress, chain, days = 7 } = params
+  const { collectionAddress, chain, days = 90 } = params
   const tickerButton = new MessageButton({
     label: "Ticker",
     emoji: emojis.TICKER,
@@ -298,11 +298,11 @@ async function composeCollectionTickerEmbed({
     },
     {
       name: `Floor price (${priceToken})`,
-      value: formatPrice(floorPriceAmount),
+      value: `${formatPrice(floorPriceAmount)} ${getEmoji(priceToken)}`,
     },
     {
       name: `Last sale (${priceToken})`,
-      value: formatPrice(lastSalePriceAmount),
+      value: `${formatPrice(lastSalePriceAmount)} ${getEmoji(priceToken)}`,
     },
     {
       name: "Change (24h)",


### PR DESCRIPTION
**What does this PR do?**

-   [x] toggle chart render and add emoji token (with option 1 day and 7 days api response does not include times and prices to render chart)

**Media (Loom or gif)**
https://www.loom.com/share/ed21a070992b44a093d945f35b30ed67
