### PR TITLE
chore: delete blank in price

### DIFF
--- a/src/commands/community/nft/ticker.ts
+++ b/src/commands/community/nft/ticker.ts
@@ -239,7 +239,6 @@ async function composeCollectionTickerEmbed({
     })
   }
 
-  const blank = getEmoji("blank")
   const {
     items,
     owners,
@@ -265,8 +264,8 @@ async function composeCollectionTickerEmbed({
   const priceToken = floor_price?.token?.symbol?.toUpperCase() ?? ""
   const marketcap = floorPriceAmount * (items ?? 0)
   const formatPrice = (amount: number) => {
-    if (!amount) return `- ${blank}`
-    return `${getCompactFormatedNumber(amount)}${blank}`
+    if (!amount) return `-`
+    return `${getCompactFormatedNumber(amount)}`
   }
   const getChangePercentage = (changeStr: string | undefined) => {
     const change = changeStr ? +changeStr : 0
@@ -282,11 +281,11 @@ async function composeCollectionTickerEmbed({
   const fields = [
     {
       name: "Item",
-      value: `${items}${blank}`,
+      value: `${items}`,
     },
     {
       name: "Owner",
-      value: `${owners}${blank}`,
+      value: `${owners}`,
     },
     {
       name: `Market cap (${priceToken})`,


### PR DESCRIPTION
**What does this PR do?**

-   [x] delete blank nft ticker

**Media (Loom or gif)**
Before:
<img width="505" alt="Screenshot 2022-11-17 at 10 00 31" src="https://user-images.githubusercontent.com/49946656/202344213-7f79be96-24e5-4598-b7ed-da0ea2a0399c.png">
 
After: 
<img width="483" alt="Screenshot 2022-11-17 at 10 26 34" src="https://user-images.githubusercontent.com/49946656/202347535-63332ccb-c0b8-44c1-b4c3-ea8d92c76193.png">

