### PR TITLE
chore: format volume number

### DIFF
--- a/src/commands/community/nft/ticker.ts
+++ b/src/commands/community/nft/ticker.ts
@@ -256,7 +256,7 @@ async function composeCollectionTickerEmbed({
     +(floor_price?.amount ?? 0) / Math.pow(10, decimals(floor_price))
   )
   const totalVolumeAmount = Math.round(
-    +(total_volume?.amount ?? 0) / Math.pow(10, decimals(total_volume))
+    +(total_volume?.amount ?? 0) / Math.pow(10, decimals(floor_price))
   )
   const lastSalePriceAmount = Math.round(
     +(last_sale_price?.amount ?? 0) / Math.pow(10, decimals(last_sale_price))


### PR DESCRIPTION
**What does this PR do?**

-   [x] format volume number (total_volume return does not have decimals so use decimals of other field with same token)

**Media (Loom or gif)**
API return does not have decimals for total volume: 
![Screenshot 2022-11-17 at 11 05 47](https://user-images.githubusercontent.com/49946656/202352552-f422118b-27af-4435-aea9-2dde90b63cc9.png)

<img width="458" alt="Screenshot 2022-11-17 at 11 04 21" src="https://user-images.githubusercontent.com/49946656/202352386-2947b4e9-8426-449b-a858-b99a305c918a.png">

