### PR TITLE
fix: tip handle case multiple spaces in command string

### DIFF
--- a/src/commands/defi/tip.ts
+++ b/src/commands/defi/tip.ts
@@ -98,7 +98,12 @@ const command: Command = {
     }
     return {
       messageOptions: {
-        ...(await handleTip(args, msg.author.id, msg.content, msg)),
+        ...(await handleTip(
+          args,
+          msg.author.id,
+          msg.content.replaceAll(/\s{2,}/gim, " "),
+          msg
+        )),
       },
     }
   },


### PR DESCRIPTION
**What does this PR do?**

-   [x] Replace all spaces (2 or more) to be a single space