### PR TITLE
fix: tip command show error msg

### DIFF
--- a/src/commands/defi/tip.ts
+++ b/src/commands/defi/tip.ts
@@ -45,7 +45,11 @@ export async function handleTip(
   )
 
   if (!ok) {
-    throw new APIError({ curl, description: log, error })
+    let message
+    if (msg instanceof Message) {
+      message = msg
+    }
+    throw new APIError({ message, curl, description: log, error })
   }
 
   const recipientIds: string[] = data.map((tx: any) => tx.recipient_id)

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -525,6 +525,7 @@ export interface RequestAddToTwitterBlackListRequest {
 
 export interface RequestAddToWatchlistRequest {
   coin_gecko_id?: string;
+  is_fiat?: boolean;
   symbol?: string;
   user_id?: string;
 }


### PR DESCRIPTION
**What does this PR do?**

-   [x] Show error message for tip command (temporary fix only, works for text command, not slash command)
