### PR TITLE
chore: add example command in help menu

### DIFF
--- a/src/commands/community/gm/index.ts
+++ b/src/commands/community/gm/index.ts
@@ -21,7 +21,7 @@ const command: Command = {
     embeds: [
       composeEmbedMessage(msg, {
         usage: `${PREFIX}gm <action>`,
-        examples: `${PREFIX}gm streak`,
+        examples: `${PREFIX}gm streak\n${PREFIX}gm config #general`,
         footer: [`Type ${PREFIX}help gm <action> for a specific action!`],
         description:
           "Configure a good morning/good night channel for users to engage and keep streaks",

--- a/src/commands/community/gm_slash/index.ts
+++ b/src/commands/community/gm_slash/index.ts
@@ -38,7 +38,7 @@ const command: SlashCommand = {
     embeds: [
       composeEmbedMessage(null, {
         usage: `${SLASH_PREFIX}gm <action>`,
-        examples: `${SLASH_PREFIX}gm streak`,
+        examples: `${SLASH_PREFIX}gm streak\n${SLASH_PREFIX}gm config #general`,
         footer: [`Type ${SLASH_PREFIX}help gm <action> for a specific action!`],
         description:
           "Configure a good morning/good night channel for users to engage and keep streaks",

--- a/src/commands/community/invite/index.ts
+++ b/src/commands/community/invite/index.ts
@@ -29,7 +29,7 @@ const command: Command = {
       composeEmbedMessage(msg, {
         footer: [`Type ${PREFIX}help invite <action> for a specific action!`],
         usage: `${PREFIX}invite <action>`,
-        examples: `${PREFIX}invite leaderboard\n${PREFIX}inv leaderboard`,
+        examples: `${PREFIX}invite leaderboard\n${PREFIX}inv leaderboard\n${PREFIX}invite config #general`,
         description:
           "Track the number of successful invites per server's member",
         document: INVITE_GITBOOK,

--- a/src/commands/community/sales/index.ts
+++ b/src/commands/community/sales/index.ts
@@ -22,7 +22,7 @@ const command: Command = {
       composeEmbedMessage(msg, {
         usage: `${PREFIX}sales <action>`,
         description: "Receive real-time notification whenever there is a sale",
-        examples: `${PREFIX}sales list\n${PREFIX}sale list`,
+        examples: `${PREFIX}sales list\n${PREFIX}sale list\n${PREFIX}sales track #general 0x7aCeE5D0acC520faB33b3Ea25D4FEEF1FfebDE73 250`,
         footer: [`Type ${PREFIX}help sales <action> for a specific action!`],
         document: SALE_TRACKER_GITBOOK,
         includeCommandsList: true,

--- a/src/commands/community/verify/index.ts
+++ b/src/commands/community/verify/index.ts
@@ -23,7 +23,7 @@ const command: Command = {
         usage: `${PREFIX}verify <action>`,
         description:
           "Verify your wallet by connecting a Metamask wallet with your Discord server to use all DeFi functions offered by Mochi",
-        examples: `${PREFIX}verify info`,
+        examples: `${PREFIX}verify info\n${PREFIX}verify set #connect-wallet @verified`,
         document: VERIFY_WALLET_GITBOOK,
         footer: [`Type ${PREFIX}help verify <action> for a specific action!`],
         includeCommandsList: true,

--- a/src/commands/community/verify_slash/index.ts
+++ b/src/commands/community/verify_slash/index.ts
@@ -33,6 +33,7 @@ const command: SlashCommand = {
     embeds: [
       composeEmbedMessage(null, {
         usage: `${SLASH_PREFIX}verify <action>`,
+        examples: `${SLASH_PREFIX}verify info\n${SLASH_PREFIX}verify set #connect-wallet @verified`,
         footer: [`Type ${SLASH_PREFIX}help verify for a specific action!`],
         includeCommandsList: true,
         originalMsgAuthor: interaction.user,

--- a/src/commands/community/vote/index.ts
+++ b/src/commands/community/vote/index.ts
@@ -181,7 +181,7 @@ const command: Command = {
     embeds: [
       composeEmbedMessage(msg, {
         usage: `${PREFIX}vote`,
-        examples: `${PREFIX}vote`,
+        examples: `${PREFIX}vote\n${PREFIX}vote top\n${PREFIX}vote set #vote`,
         includeCommandsList: true,
         document: VOTE_GITBOOK,
         description:

--- a/src/commands/community/vote/vote_slash.ts
+++ b/src/commands/community/vote/vote_slash.ts
@@ -1,6 +1,6 @@
 import { SlashCommandBuilder } from "@discordjs/builders"
 import { SlashCommand } from "types/common"
-import { PREFIX } from "utils/constants"
+import { SLASH_PREFIX as PREFIX } from "utils/constants"
 import { composeEmbedMessage } from "utils/discordEmbed"
 import { handle } from "./"
 
@@ -12,6 +12,7 @@ const command: SlashCommand = {
       embeds: [
         composeEmbedMessage(null, {
           usage: `${PREFIX}vote`,
+          examples: `${PREFIX}vote\n${PREFIX}vote top\n${PREFIX}vote set #vote`,
           includeCommandsList: true,
         }),
       ],

--- a/src/commands/config/defaultRole/index.ts
+++ b/src/commands/config/defaultRole/index.ts
@@ -28,7 +28,7 @@ const command: Command = {
     embeds: [
       composeEmbedMessage(msg, {
         usage: `${PREFIX}dr <action>\n${PREFIX}defaultrole <action>`,
-        examples: `${PREFIX}defaultrole info\n${PREFIX}dr info`,
+        examples: `${PREFIX}defaultrole info\n${PREFIX}dr info\n${PREFIX}defaultrole set @visitor`,
         description:
           "Set a default role that will automatically assigned to newcomers when they first join your server",
         footer: [`Type ${PREFIX}help dr <action> for a specific action!`],

--- a/src/commands/config/defaultRole_slash/index.ts
+++ b/src/commands/config/defaultRole_slash/index.ts
@@ -36,6 +36,7 @@ const command: SlashCommand = {
     embeds: [
       composeEmbedMessage2(interaction, {
         usage: `${SLASH_PREFIX}defaultrole <sub-command>`,
+        examples: `${SLASH_PREFIX}defaultrole info\n${SLASH_PREFIX}dr info\n${SLASH_PREFIX}defaultrole set @visitor`,
         description:
           "Set a default role that will automatically assigned to newcomers when they first join your server",
         footer: [`Type ${SLASH_PREFIX}help dr <action> for a specific action!`],

--- a/src/commands/config/log/index.ts
+++ b/src/commands/config/log/index.ts
@@ -26,7 +26,7 @@ const command: Command = {
         footer: [`Type ${PREFIX}help log <action> for a specific action!`],
         document: LOG_CHANNEL_GITBOOK,
         title: "Log channel",
-        examples: `${PREFIX}log info`,
+        examples: `${PREFIX}log info\n${PREFIX}log set #log-channel`,
       }),
     ],
   }),

--- a/src/commands/config/nftRole/index.ts
+++ b/src/commands/config/nftRole/index.ts
@@ -30,7 +30,7 @@ const command: Command = {
         usage: `${PREFIX}nr <action>\n${PREFIX}nftrole <action>`,
         description:
           "Asssign role to a user once they hold a certain amount of NFT\nSupports multiple collections and grouping",
-        examples: `${PREFIX}nr list\n${PREFIX}nftrole list`,
+        examples: `${PREFIX}nr list\n${PREFIX}nftrole list\n${PREFIX}nftrole set @Mochi 1 0x7aCeE5D0acC520faB33b3Ea25D4FEEF1FfebDE73`,
         footer: [`Type ${PREFIX}help nr <action> for a specific action!`],
         includeCommandsList: true,
         document: NFT_ROLE_GITBOOK,

--- a/src/commands/config/nftRole_slash/index.ts
+++ b/src/commands/config/nftRole_slash/index.ts
@@ -38,7 +38,7 @@ const command: SlashCommand = {
         usage: `${PREFIX}nftrole <action>\n${PREFIX}nftrole <action>`,
         description:
           "Asssign role to a user once they hold a certain amount of NFT\nSupports multiple collections and grouping",
-        examples: `${PREFIX}nftrole list\n${PREFIX}nftrole list`,
+        examples: `${PREFIX}nr list\n${PREFIX}nftrole list\n${PREFIX}nftrole set @Mochi 1 0x7aCeE5D0acC520faB33b3Ea25D4FEEF1FfebDE73`,
         footer: [`Type ${PREFIX}help nftrole <action> for a specific action!`],
         includeCommandsList: true,
         document: NFT_ROLE_GITBOOK,

--- a/src/commands/config/reactionRole/index.ts
+++ b/src/commands/config/reactionRole/index.ts
@@ -27,7 +27,7 @@ const command: Command = {
     embeds: [
       composeEmbedMessage(msg, {
         usage: `${PREFIX}rr <action>`,
-        examples: `${PREFIX}reactionrole list\n${PREFIX}rr list`,
+        examples: `${PREFIX}reactionrole list\n${PREFIX}rr list\n${PREFIX}reactionrole set https://discord.com/channels/...4875 ✅ @Visitor`,
         description: "Assign a role corresponding to users' reaction",
         footer: [`Type ${PREFIX}help rr <action> for a specific action!`],
         document: REACTION_ROLE_GITBOOK,

--- a/src/commands/config/reactionRole_slash/index.ts
+++ b/src/commands/config/reactionRole_slash/index.ts
@@ -36,7 +36,7 @@ const command: SlashCommand = {
     embeds: [
       composeEmbedMessage2(interaction, {
         usage: `${PREFIX}reactionrole <action>`,
-        examples: `${PREFIX}reactionrole list`,
+        examples: `${PREFIX}reactionrole list\n${PREFIX}rr list\n${PREFIX}reactionrole set https://discord.com/channels/...4875 ✅ @Visitor`,
         description: "Assign a role corresponding to users' reaction",
         footer: [
           `Type ${PREFIX}help reactionrole <action> for a specific action!`,

--- a/src/commands/config/telegram/index.ts
+++ b/src/commands/config/telegram/index.ts
@@ -21,7 +21,7 @@ const command: Command = {
         title: "Telegram configuration",
         description: "Manage your linked Telegram account",
         usage: `${PREFIX}telegram <action>`,
-        examples: `${PREFIX}telegram config`,
+        examples: `${PREFIX}telegram config\n${PREFIX}telegram config anhnhhhh`,
         document: TELEGRAM_GITBOOK,
         includeCommandsList: true,
       }),

--- a/src/commands/defi/ticker/ticker.ts
+++ b/src/commands/defi/ticker/ticker.ts
@@ -501,7 +501,7 @@ const command: Command = {
         thumbnail: thumbnails.TOKENS,
         description: `Display/Compare coin prices and market cap. Data is fetched from [CoinGecko](https://coingecko.com/)`,
         usage: `${PREFIX}ticker <symbol>\n${PREFIX}ticker <base>/<target> (comparison)\n${PREFIX}ticker <action>`,
-        examples: `${PREFIX}ticker eth\n${PREFIX}ticker fantom\n${PREFIX}ticker btc/bnb`,
+        examples: `${PREFIX}ticker eth\n${PREFIX}ticker fantom\n${PREFIX}ticker btc/bnb\n${PREFIX}ticker default eth`,
         document: TICKER_GITBOOK,
         footer: [DEFI_DEFAULT_FOOTER],
         includeCommandsList: true,

--- a/src/commands/defi/ticker_slash/ticker_slash.ts
+++ b/src/commands/defi/ticker_slash/ticker_slash.ts
@@ -436,7 +436,7 @@ const command: SlashCommand = {
         title: "Display/Compare coin price and market cap",
         description: `Data is fetched from [CoinGecko](https://coingecko.com/)`,
         usage: `${PREFIX}ticker <symbol>\n${PREFIX}ticker <base>/<target> (comparison)`,
-        examples: `${PREFIX}ticker eth\n${PREFIX}ticker fantom\n${PREFIX}ticker btc/bnb`,
+        examples: `${PREFIX}ticker eth\n${PREFIX}ticker fantom\n${PREFIX}ticker btc/bnb\n${PREFIX}ticker default eth`,
       }),
     ],
   }),

--- a/src/commands/defi/token/index.ts
+++ b/src/commands/defi/token/index.ts
@@ -32,7 +32,7 @@ const command: Command = {
         thumbnail: thumbnails.TOKENS,
         description: "Manage all supported tokens by Mochi",
         usage: `${PREFIX}tokens`,
-        examples: `${PREFIX}tokens list\n${PREFIX}token list`,
+        examples: `${PREFIX}tokens list\n${PREFIX}token list\n${PREFIX}tokens add-custom 0x22c36BfdCef207F9c0CC941936eff94D4246d14A BACC eth`,
         document: TOKEN_GITBOOK,
         footer: [`Type ${PREFIX}help token <action> for a specific action!`],
         includeCommandsList: true,

--- a/src/commands/defi/watchlist/index.ts
+++ b/src/commands/defi/watchlist/index.ts
@@ -33,7 +33,7 @@ const command: Command = {
         title: "Manage your watchlist",
         description: "Manage your watchlist for selected tokens/nfts",
         usage: `${PREFIX}watchlist <action>`,
-        examples: `${PREFIX}wl view`,
+        examples: `${PREFIX}wl view\n${PREFIX}watchlist add eth\n${PREFIX}watchlist add-nft neko`,
         document: WATCHLIST_GITBOOK,
         footer: [
           `Type ${PREFIX}help watchlist <action> for a specific action!.`,

--- a/src/commands/defi/watchlist_slash/index.ts
+++ b/src/commands/defi/watchlist_slash/index.ts
@@ -88,6 +88,7 @@ const command: SlashCommand = {
         thumbnail: thumbnails.TOKENS,
         title: "Manage your watchlist",
         usage: `${PREFIX}watchlist <sub-command>`,
+        examples: `${PREFIX}wl view\n${PREFIX}watchlist add eth\n${PREFIX}watchlist add-nft neko`,
       }),
     ],
   }),

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1833,6 +1833,10 @@ export interface ResponseToggleActivityConfigResponse {
   message?: string;
 }
 
+export interface ResponseTransactionsResponse {
+  data?: ResponseTransactionsResponse[];
+}
+
 export interface ResponseTwitterHashtag {
   channel_id?: string;
   created_at?: string;


### PR DESCRIPTION
**What does this PR do?**

-   [x] add example command in help menu (check list: https://www.notion.so/console-labs/Example-in-command-main-help-menu-7d48fb6229b241b7b70eec78d69d23a0)


**Media (Loom or gif)**
<img width="536" alt="Screenshot 2022-11-23 at 12 44 35" src="https://user-images.githubusercontent.com/49946656/203478429-79ef7cbf-c5e3-4088-a0c3-8b35268f8ad3.png">
<img width="529" alt="Screenshot 2022-11-23 at 12 44 50" src="https://user-images.githubusercontent.com/49946656/203478494-4626bf29-83cf-4a91-83c8-d1ee577f3ab3.png">
<img width="526" alt="Screenshot 2022-11-23 at 12 45 02" src="https://user-images.githubusercontent.com/49946656/203478566-6a50ce10-188e-47a3-bc8c-9dd8a3832bde.png">
<img width="513" alt="Screenshot 2022-11-23 at 12 45 19" src="https://user-images.githubusercontent.com/49946656/203478642-4e44f2be-0ac2-4601-bf0a-98af295638fb.png">

