### PR TITLE
chore: fix-embed-msg-nft-stats

### DIFF
--- a/src/commands/community/nft/stats.ts
+++ b/src/commands/community/nft/stats.ts
@@ -18,9 +18,9 @@ const command: Command = {
     let description = ``
     if (res.data) {
       res.data.data?.forEach((v: any) => {
-        description += `${getEmoji(v.chain.currency)} ${v.chain.currency}: ${
-          v.count
-        } collections\n`
+        description += `${getEmoji(v.chain.currency)} **${
+          v.chain.currency
+        }**: ${v.count} collections\n\n`
       })
     }
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -359,15 +359,6 @@ export interface ModelOffchainTipBotAssignContract {
   user_id?: string;
 }
 
-export interface ModelOffchainTipBotConfigNotify {
-  channel_id?: string;
-  created_at?: string;
-  guild_id?: string;
-  id?: string;
-  token?: string;
-  updated_at?: string;
-}
-
 export interface ModelOffchainTipBotContract {
   assign_status?: number;
   centralize_wallet?: string;
@@ -1057,6 +1048,16 @@ export interface ResponseConfigGroupNFTRoleResponse {
   role_id?: string;
 }
 
+export interface ResponseConfigNotifyResponse {
+  channel_id?: string;
+  created_at?: string;
+  guild_id?: string;
+  id?: string;
+  token?: string;
+  total_transaction?: number;
+  updated_at?: string;
+}
+
 export interface ResponseConfigureInvitesResponse {
   data?: string;
 }
@@ -1667,7 +1668,7 @@ export interface ResponseListAllNFTCollectionsResponse {
 }
 
 export interface ResponseListConfigNotifyResponse {
-  data?: ModelOffchainTipBotConfigNotify[];
+  data?: ResponseConfigNotifyResponse[];
 }
 
 export interface ResponseListCustomCommandsResponse {
@@ -1736,6 +1737,11 @@ export interface ResponseMonikerConfigResponse {
   data?: ResponseMonikerConfigData[];
 }
 
+export interface ResponseNFTChainCollectionCount {
+  chain?: ModelChain;
+  count?: number;
+}
+
 export interface ResponseNFTCollectionConfig {
   address?: string;
   author?: string;
@@ -1753,9 +1759,7 @@ export interface ResponseNFTCollectionConfig {
 }
 
 export interface ResponseNFTCollectionCount {
-  eth_collection?: number;
-  ftm_collection?: number;
-  op_collection?: number;
+  data?: ResponseNFTChainCollectionCount[];
   total?: number;
 }
 

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -76,6 +76,8 @@ export const tokenEmojis: Record<string, string> = {
   ANC: "1037985575334051901",
   BRUSH: "1037985582162378783",
   SOL: "1006838270862295080",
+  APT: "1047707078183096320",
+  RONIN: "1047707529884483614",
 }
 
 export const numberEmojis: Record<string, string> = {


### PR DESCRIPTION
**What does this PR do?**

-   [x] Fix embedded msg nft stats

**Media (Loom or gif)**
Before
<img width="489" alt="Screenshot 2022-12-01 at 09 38 17" src="https://user-images.githubusercontent.com/49946656/204952724-309d79fd-e565-404e-ae88-d48971c59152.png">
After
<img width="470" alt="Screenshot 2022-12-01 at 09 38 30" src="https://user-images.githubusercontent.com/49946656/204952744-52943713-89b2-49fe-beb9-556720e6480a.png">
