### PR TITLE
fix: default role set help menu

### DIFF
--- a/src/commands/config/defaultRole/set.ts
+++ b/src/commands/config/defaultRole/set.ts
@@ -66,10 +66,10 @@ const command: Command = {
     return {
       embeds: [
         composeEmbedMessage(msg, {
-          usage: `${PREFIX}dr set @<role_name>`,
+          usage: `${PREFIX}dr set <@role_name/roleID>`,
           title: "Setting a default role",
           description:
-            "If you know what you're doing, this command also support passing in the role id (maybe you're a power user, maybe you don't want to alert all users that have that role, etc...)",
+            "If you don't want to notify users when setting up the default role, you can use role ID instead of role name.\n\nNote: To get the roleID\n👉 _Go to Server Setting, and choose Roles_\n👉 _Select a role, and copy its ID_",
           examples: `${PREFIX}dr set @Visitor`,
           document: `${DEFAULT_ROLE_GITBOOK}&action=set`,
         }),


### PR DESCRIPTION
**What does this PR do?**

-   [x] Update the help menu message of $dr set

**Media (Loom or gif)**
<img width="600" alt="CleanShot 2022-12-07 at 14 57 18@2x" src="https://user-images.githubusercontent.com/25856620/206120869-0c51786f-ef60-4721-8501-f01f568ef69d.png">

