### PR TITLE
fix: poe twitter stats ui tweak

### DIFF
--- a/src/commands/config/poe/twitter/stats.ts
+++ b/src/commands/config/poe/twitter/stats.ts
@@ -34,36 +34,34 @@ const command: Command = {
 
     const data = _data?.data ?? []
 
-    const handles = data.map((d: any) => {
-      return `\`${DOT} ${d.twitter_handle}    =>\``
-    })
+    const handles = data.map((d: any) => d.twitter_handle)
 
     const longestHandle =
       handles.sort((a: string, b: string) => b.length - a.length)[0]?.length ??
       0
 
     const formattedHandles = data.map((d: any) => {
-      return `\`${DOT} ${d.twitter_handle}${Array(
-        longestHandle - 6 - d.twitter_handle.length
+      return `${DOT} ${d.twitter_handle}${Array(
+        longestHandle - d.twitter_handle.length + 4
       )
         .fill(" ")
-        .join("")}=>\``
+        .join("")}=>`
     })
 
     const topScore = data[0].total_count
     const topDigits = topScore.toString().length
 
     const formattedScores = data.map((d: any) => {
-      return `\`${Array(topDigits - d.total_count.toString().length)
+      return `${Array(topDigits - d.total_count.toString().length)
         .fill(" ")
-        .join("")}${d.total_count}\``
+        .join("")}${d.total_count}`
     })
 
     return {
       messageOptions: {
         content: `__Top 10 Twitter users__:\n${formattedHandles
           .map((fh: string, i: number) => {
-            return `${fh} ${formattedScores[i]}`
+            return `\`${fh} ${formattedScores[i]}\``
           })
           .join("\n")}`,
       },


### PR DESCRIPTION
**What does this PR do?**

-   [x] Join two code text together

**How to test**
`$poe twitter stats`

**Media (Loom or gif)**
|Before|After|
|---|---|
|<img width="264" alt="CleanShot 2022-12-07 at 15 07 22@2x" src="https://user-images.githubusercontent.com/25856620/206123464-7ab0fb46-b61a-4283-b605-f0bc86b9ace2.png">|<img width="258" alt="CleanShot 2022-12-07 at 15 07 25@2x" src="https://user-images.githubusercontent.com/25856620/206123489-615004a7-6019-4603-89c5-50ac2cfbbef1.png">|
