### PR TITLE
fix: handle different cases of gm config

### DIFF
--- a/src/commands/community/gm/config.ts
+++ b/src/commands/community/gm/config.ts
@@ -56,26 +56,32 @@ const command: Command = {
         description: "Invalid channel. Type #, then choose the valid one!",
       })
     }
-    const messageText = args[3] ?? "gm/gn"
-    const emoji = args[4] ?? getEmoji("gm")
     const stickerArg = msg.stickers.first()?.id ?? ""
+    let messageText = "gm/gn"
+    let emoji = getEmoji("gm")
 
-    const { isEmoji, isNativeEmoji, isAnimatedEmoji } = parseDiscordToken(emoji)
+    let { isEmoji, isNativeEmoji, isAnimatedEmoji } = parseDiscordToken(
+      args[4] ?? ""
+    )
     if (!isEmoji && !isNativeEmoji && !isAnimatedEmoji) {
-      throw new InternalError({
-        message: msg,
-        description: "Invalid emoji",
-      })
+      // maybe the user is only setting emoji and no phrase -> check if the 3rd argument is emoji
+      ;({ isEmoji, isNativeEmoji, isAnimatedEmoji } = parseDiscordToken(
+        args[3] ?? ""
+      ))
+
+      if (!isEmoji && !isNativeEmoji && !isAnimatedEmoji) {
+        // maybe user is only setting phrase ->
+        messageText = args[3]
+      } else {
+        emoji = args[3]
+      }
+    } else {
+      messageText = args[3]
+      emoji = args[4]
     }
     throwOnInvalidEmoji(emoji, msg)
 
-    return await handle(
-      msg.guildId,
-      channelId,
-      messageText,
-      args[4],
-      stickerArg
-    )
+    return await handle(msg.guildId, channelId, messageText, emoji, stickerArg)
   },
   getHelpMessage: async (msg) => ({
     embeds: [

--- a/src/utils/emoji.ts
+++ b/src/utils/emoji.ts
@@ -7,8 +7,8 @@ export function throwOnInvalidEmoji(emoji: string, msg: OriginalMessage) {
   let isValidEmoji = false
 
   msg.guild?.emojis.cache?.forEach((e) => {
-    if (e.name) {
-      if (value.includes(e.name.toLowerCase())) {
+    if (e.id) {
+      if (value === e.id) {
         isValidEmoji = true
       }
     }


### PR DESCRIPTION
**What does this PR do?**

-   [x] Handle case only phrase, no emoji
-   [x] Handle case only emoji, no phrase

**How to test**
`$gm config #general morning`
`$gm config #general 🌔`

**Media (Loom or gif)**
<img width="605" alt="CleanShot 2022-12-07 at 17 22 50@2x" src="https://user-images.githubusercontent.com/25856620/206153542-dba76aa6-51b4-4490-bd3f-1c8eb153a5c0.png">

<img width="595" alt="CleanShot 2022-12-07 at 17 22 44@2x" src="https://user-images.githubusercontent.com/25856620/206153553-0511a5cb-6c85-4946-9288-44a820c4fe7e.png">

