### PR TITLE
feat: remove wd address validation

### DIFF
--- a/src/adapters/defi.ts
+++ b/src/adapters/defi.ts
@@ -445,9 +445,9 @@ class Defi extends Fetcher {
     }
     const guildId = msg.guildId ?? "DM"
 
-    if (!toAddress.startsWith("0x")) {
-      throw new Error("Invalid destination address")
-    }
+    // if (!toAddress.startsWith("0x")) {
+    //   throw new Error("Invalid destination address")
+    // }
     const recipients = [toAddress]
     const cryptocurrency = token.toUpperCase()
 

--- a/src/commands/defi/withdraw.ts
+++ b/src/commands/defi/withdraw.ts
@@ -3,11 +3,7 @@ import { CommandInteraction, Message } from "discord.js"
 import { DEFI_DEFAULT_FOOTER, DEPOSIT_GITBOOK, PREFIX } from "utils/constants"
 import { getCommandArguments } from "utils/commands"
 import Defi from "adapters/defi"
-import {
-  composeButtonLink,
-  composeEmbedMessage,
-  getErrorEmbed,
-} from "utils/discordEmbed"
+import { composeButtonLink, composeEmbedMessage } from "utils/discordEmbed"
 import { getEmoji, getEmojiURL, emojis } from "utils/common"
 import { APIError, CommandArgumentError } from "errors"
 import { OffchainTipBotWithdrawRequest } from "types/defi"
@@ -23,17 +19,17 @@ export async function getDestinationAddress(
     filter,
   })
   const userReply = collected.first()
-  if (userReply && !userReply.content.trim().startsWith("0x")) {
-    await userReply.reply({
-      embeds: [
-        getErrorEmbed({
-          description: "Invalid input!\nPlease re-enter a valid address...",
-        }),
-      ],
-    })
-    return await getDestinationAddress(msg, dm)
-  }
-  return userReply?.content.trim() ?? ""
+  // if (userReply && !userReply.content.trim().startsWith("0x")) {
+  //   await userReply.reply({
+  //     embeds: [
+  //       getErrorEmbed({
+  //         description: "Invalid input!\nPlease re-enter a valid address...",
+  //       }),
+  //     ],
+  //   })
+  //   return await getDestinationAddress(msg, dm)
+  // }
+  return userReply?.content?.trim() ?? ""
 }
 
 async function withdraw(msg: Message, args: string[]) {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -980,6 +980,10 @@ export interface ResponseAddToWatchlistResponseData {
   target_suggestions?: ModelCoingeckoSupportedTokens[];
 }
 
+export interface ResponseAllTipBotTokensResponse {
+  data?: ModelOffchainTipBotToken[];
+}
+
 export interface ResponseClaimQuestsRewardsResponse {
   data?: ResponseClaimQuestsRewardsResponseData;
 }


### PR DESCRIPTION
**What does this PR do?**
-   [x] Remove old withdraw address validation (starts with `0x`): we support solana now

**Media**
![ảnh](https://user-images.githubusercontent.com/34529672/207499690-d7ce12c8-5bc6-48a9-ade6-4ec281e1b199.png)