### PR TITLE
fix: nft attr name

### DIFF
--- a/src/commands/nft/query/processor.ts
+++ b/src/commands/nft/query/processor.ts
@@ -525,7 +525,7 @@ export async function composeNFTDetail(
         const val = `${capFirst(attr.value)}\n${attr.frequency ?? ""}`
         return {
           name: `${getIcon(icons, attr.trait_type)} ${capFirst(
-            attr.trait_type
+            attr.trait_type?.replace("_", " ")
           )}`,
           value: `${val ? val : "-"}`,
           inline: true,


### PR DESCRIPTION
**What does this PR do?**
- [x] $nft query: remove `_` in attribute name

**Media**
![image](https://user-images.githubusercontent.com/34529672/219600646-96243232-1651-4968-86f6-d4da31150a18.png)