### PR TITLE
Fix: log info emoji

### DIFF
--- a/src/commands/log/info/processor.ts
+++ b/src/commands/log/info/processor.ts
@@ -1,7 +1,7 @@
 import config from "adapters/config"
 import { Message } from "discord.js"
 import { GuildIdNotFoundError } from "errors"
-import { getEmoji } from "utils/common"
+import { emojis, getEmojiURL } from "utils/common"
 import { PREFIX } from "utils/constants"
 import { composeEmbedMessage } from "ui/discord/embed"
 
@@ -21,14 +21,14 @@ export async function runLogInfo({
   }
   if (!guildCfg.log_channel) {
     const embed = composeEmbedMessage(msg, {
-      author: ["Log channel", getEmoji("SHELTER")],
+      author: ["Log channel", getEmojiURL(emojis.SHELTER)],
       description: `No logging channel configured for this guild.\nSet one with \`${PREFIX}log set <channel>.\``,
     })
     return { messageOptions: { embeds: [embed] } }
   }
 
   const embed = composeEmbedMessage(msg, {
-    author: ["Log channel", getEmoji("SHELTER")],
+    author: ["Log channel", getEmojiURL(emojis.SHELTER)],
     description: `All activities will be monitored in <#${guildCfg.log_channel}>. To change this channel, run \`$log set #<channel>\`.`,
   })
   return { messageOptions: { embeds: [embed] } }

--- a/tests/assertions/discord.ts
+++ b/tests/assertions/discord.ts
@@ -12,7 +12,18 @@ export function assertRunResult(
   if (expected?.messageOptions?.embeds?.[0]) {
     expected.messageOptions.embeds[0].timestamp = null
   }
-  expect(output).toStrictEqual(expected)
+  expect(output.messageOptions.embeds).toStrictEqual(
+    expected.messageOptions.embeds
+  )
+  expect(output.messageOptions.components).toStrictEqual(
+    expected.messageOptions.components
+  )
+  expect(output.messageOptions.content).toStrictEqual(
+    expected.messageOptions.content
+  )
+  expect(output.messageOptions.files).toStrictEqual(
+    expected.messageOptions.files
+  )
 }
 
 export function assertThumbnail(


### PR DESCRIPTION
**What does this PR do?**
-   [x] `$log info`:  pass emoji to `author` -> should pass emoji URL instead
