### PR TITLE
fix: withdraw - address validation

### DIFF
--- a/src/adapters/defi.ts
+++ b/src/adapters/defi.ts
@@ -127,28 +127,28 @@ class Defi extends Fetcher {
     msgOrInteraction: Message | CommandInteraction,
     current: number,
     required: number,
-    cryptocurrency: string
+    symbol: string
   ) {
-    const tokenEmoji = getEmoji(cryptocurrency)
-    const symbol = cryptocurrency.toUpperCase()
+    const tokenEmoji = getEmoji(symbol)
     const authorId =
       msgOrInteraction instanceof Message
         ? msgOrInteraction.author.id
         : msgOrInteraction.user.id
     return composeEmbedMessage(null, {
       author: ["Insufficient balance", getEmojiURL(emojis.REVOKE)],
-      description: `<@${authorId}>, your balance is insufficient.\nYou can deposit more by using \`$deposit ${cryptocurrency}\``,
-    })
-      .addField(
-        "Required amount",
-        `${tokenEmoji} ${roundFloatNumber(required, 4)} ${symbol}`,
-        true
-      )
-      .addField(
-        "Your balance",
-        `${tokenEmoji} ${roundFloatNumber(current, 4)} ${symbol}`,
-        true
-      )
+      description: `<@${authorId}>, your balance is insufficient.\nYou can deposit more by using \`$deposit ${symbol}\``,
+    }).addFields([
+      {
+        name: "Required amount",
+        value: `${tokenEmoji} ${roundFloatNumber(required, 4)} ${symbol}`,
+        inline: true,
+      },
+      {
+        name: "Your balance",
+        value: `${tokenEmoji} ${roundFloatNumber(current, 4)} ${symbol}`,
+        inline: true,
+      },
+    ])
   }
 
   async getUserWatchlist({

--- a/src/commands/airdrop/index/processor.ts
+++ b/src/commands/airdrop/index/processor.ts
@@ -413,7 +413,7 @@ export async function getAirdropPayload(
     throw new InternalError({
       message: msg,
       title: "Unsupported token",
-      description: `**${cryptocurrency.toUpperCase()}** hasn't been supported.\n${getEmoji(
+      description: `**${cryptocurrency}** hasn't been supported.\n${getEmoji(
         "POINTINGRIGHT"
       )} Please choose one in our supported \`$token list\` or \`$moniker list\`!\n${getEmoji(
         "POINTINGRIGHT"

--- a/src/commands/withdraw/index/processor.test.ts
+++ b/src/commands/withdraw/index/processor.test.ts
@@ -8,13 +8,13 @@ import { composeEmbedMessage } from "ui/discord/embed"
 import { emojis, getEmoji, getEmojiURL, roundFloatNumber } from "utils/common"
 import { assertRunResult } from "../../../../tests/assertions/discord"
 jest.mock("adapters/defi")
-jest.mock("utils/common")
+// jest.mock("utils/common")
 
 describe("getDestinationAddress", () => {
   const interaction = mockdc.cloneCommandInteraction()
   const msg = mockdc.cloneMessage()
   const mockedCollectedMessage = mockdc.cloneMessage()
-  mockedCollectedMessage.content = "0xE409E073eE7474C381BFD9b3f88098499123123"
+  mockedCollectedMessage.content = "0xA94FCFbf927594702f8F0Eb7532f35928F32410b"
   const mockedCollected = new Collection<string, Message<boolean>>()
   mockedCollected.set("test", mockedCollectedMessage)
 
@@ -22,13 +22,17 @@ describe("getDestinationAddress", () => {
   mockedDm.channel.awaitMessages = jest.fn().mockResolvedValue(mockedCollected)
 
   test("getSuccess using Message", async () => {
-    const output = await processor.getDestinationAddress(msg, mockedDm)
-    expect(output).toEqual("0xE409E073eE7474C381BFD9b3f88098499123123")
+    const output = await processor.getDestinationAddress(msg, mockedDm, "FTM")
+    expect(output).toEqual("0xA94FCFbf927594702f8F0Eb7532f35928F32410b")
   })
 
   test("getSuccess using Message", async () => {
-    const output = await processor.getDestinationAddress(interaction, mockedDm)
-    expect(output).toEqual("0xE409E073eE7474C381BFD9b3f88098499123123")
+    const output = await processor.getDestinationAddress(
+      interaction,
+      mockedDm,
+      "FTM"
+    )
+    expect(output).toEqual("0xA94FCFbf927594702f8F0Eb7532f35928F32410b")
   })
 })
 

--- a/src/commands/withdraw/index/slash.test.ts
+++ b/src/commands/withdraw/index/slash.test.ts
@@ -1,11 +1,11 @@
+import Defi from "adapters/defi"
 import { slashCommands } from "commands"
 import { CommandInteraction, MessageOptions } from "discord.js"
 import { RunResult } from "types/common"
-import { composeEmbedMessage, getErrorEmbed } from "ui/discord/embed"
+import { composeEmbedMessage } from "ui/discord/embed"
 import { emojis, getEmojiURL } from "utils/common"
 import { assertRunResult } from "../../../../tests/assertions/discord"
 import mockdc from "../../../../tests/mocks/discord"
-import Defi from "adapters/defi"
 import * as processor from "./processor"
 jest.mock("adapters/defi")
 
@@ -14,22 +14,6 @@ describe("run", () => {
   const withdrawCmd = slashCommands["withdraw"]
 
   beforeEach(() => (i = mockdc.cloneCommandInteraction()))
-
-  test("missing arguments error", async () => {
-    i.options.getNumber = jest.fn().mockReturnValueOnce(null)
-    i.options.getString = jest.fn().mockReturnValueOnce(null)
-    const output = (await withdrawCmd.run(i)) as RunResult<MessageOptions>
-    const expected = {
-      messageOptions: {
-        embeds: [
-          getErrorEmbed({
-            description: "Missing arguments",
-          }),
-        ],
-      },
-    }
-    assertRunResult(output, expected)
-  })
 
   test("insufficient balance", async () => {
     i.options.getNumber = jest.fn().mockReturnValueOnce(1)
@@ -66,7 +50,7 @@ describe("run", () => {
     expect(processor.withdrawSlash).toHaveBeenCalledWith(
       i,
       "1",
-      "ftm",
+      "FTM",
       "0xE409E073eE7474C381BFD9b3f88098499123123"
     )
   })

--- a/src/commands/withdraw/index/slash.ts
+++ b/src/commands/withdraw/index/slash.ts
@@ -1,24 +1,13 @@
 import defi from "adapters/defi"
 import { CommandInteraction } from "discord.js"
-import { emojis, getEmojiURL } from "utils/common"
-import { composeEmbedMessage, getErrorEmbed } from "ui/discord/embed"
-import * as processor from "./processor"
 import { composeButtonLink } from "ui/discord/button"
+import { composeEmbedMessage } from "ui/discord/embed"
+import { emojis, getEmojiURL } from "utils/common"
+import * as processor from "./processor"
 
 const run = async (interaction: CommandInteraction) => {
-  const amount = interaction.options.getNumber("amount")
-  const token = interaction.options.getString("token")
-  if (!amount || !token) {
-    return {
-      messageOptions: {
-        embeds: [
-          getErrorEmbed({
-            description: "Missing arguments",
-          }),
-        ],
-      },
-    }
-  }
+  const amount = interaction.options.getNumber("amount", true)
+  const token = interaction.options.getString("token", true).toUpperCase()
   // check balance
   const invalidBalEmbed = await defi.getInsuffientBalanceEmbed(
     interaction,
@@ -38,7 +27,7 @@ const run = async (interaction: CommandInteraction) => {
     embeds: [
       composeEmbedMessage(null, {
         author: ["Withdraw message", getEmojiURL(emojis.WALLET)],
-        description: `Please enter your **${token.toUpperCase()}** destination address that you want to withdraw your tokens below.`,
+        description: `Please enter your **${token}** destination address that you want to withdraw your tokens below.`,
       }),
     ],
   })
@@ -54,7 +43,7 @@ const run = async (interaction: CommandInteraction) => {
       components: [composeButtonLink("See the DM", dm.url)],
     })
   }
-  const addr = await processor.getDestinationAddress(interaction, dm)
+  const addr = await processor.getDestinationAddress(interaction, dm, token)
   return await processor.withdrawSlash(
     interaction,
     amount.toString(),

--- a/src/commands/withdraw/index/text.ts
+++ b/src/commands/withdraw/index/text.ts
@@ -10,8 +10,8 @@ import { composeButtonLink } from "ui/discord/button"
 const run = async (msg: Message) => {
   const args = getCommandArguments(msg)
   // $withdraw n <token>
-  const amount = args[1]
-  if (Number.isNaN(amount) || +amount <= 0) {
+  const amount = Number(args[1])
+  if (Number.isNaN(amount) || amount <= 0) {
     throw new InternalError({
       message: msg,
       title: "Withdraw failed!",
@@ -19,11 +19,12 @@ const run = async (msg: Message) => {
     })
   }
   // check balance
+  const symbol = args[2].toUpperCase()
   const invalidBalEmbed = await defi.getInsuffientBalanceEmbed(
     msg,
     msg.author.id,
-    args[2],
-    Number(args[1]),
+    symbol,
+    amount,
     false
   )
   if (invalidBalEmbed) {
@@ -37,7 +38,7 @@ const run = async (msg: Message) => {
     embeds: [
       composeEmbedMessage(msg, {
         author: ["Withdraw message", getEmojiURL(emojis.WALLET)],
-        description: `Please enter your **${args[2].toUpperCase()}** destination address that you want to withdraw your tokens below.`,
+        description: `Please enter your **${symbol}** destination address that you want to withdraw your tokens below.`,
       }),
     ],
   })
@@ -53,7 +54,7 @@ const run = async (msg: Message) => {
       components: [composeButtonLink("See the DM", dm.url)],
     })
   }
-  args[3] = await processor.getDestinationAddress(msg, dm)
+  args[3] = await processor.getDestinationAddress(msg, dm, symbol)
   await processor.withdraw(msg, args)
 
   return null

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -582,11 +582,10 @@ export async function pullImage(imageUrl: string): Promise<Buffer> {
 }
 
 export function isAddress(address: string): { valid: boolean; type: string } {
-  if (ethers.utils.isAddress(address)) {
-    return { valid: true, type: "eth" }
-  }
-  // solana
   try {
+    if (ethers.utils.isAddress(address)) {
+      return { valid: true, type: "eth" }
+    }
     if (PublicKey.isOnCurve(new PublicKey(address))) {
       return { valid: true, type: "sol" }
     }


### PR DESCRIPTION
**What does this PR do?**
-   [x] `$withdraw`: add address validation

**Media**
1. EVM wallet
<img width="698" alt="image" src="https://user-images.githubusercontent.com/34529672/220314131-90b3f824-e53e-451f-9a36-77b1e326be8b.png">

2. solana wallet (ignore last error -> dont have any SOL left to make it successful)
<img width="698" alt="image" src="https://user-images.githubusercontent.com/34529672/220314371-a1b232a4-4230-4205-b67d-985a66e939dd.png">
