### PR TITLE
refactor: migrate wallet slash command

### DIFF
--- a/src/commands/alert/add/text.ts
+++ b/src/commands/alert/add/text.ts
@@ -95,7 +95,7 @@ const command: Command = {
         composeEmbedMessage(msg, {
           usage: `${PREFIX}alert add <token>`,
           examples: `${PREFIX}alert add ftm`,
-          document: `${PRICE_ALERT_GITBOOK}`,
+          document: `${PRICE_ALERT_GITBOOK}&action=add`,
         }),
       ],
     }

--- a/src/commands/alert/list/text.ts
+++ b/src/commands/alert/list/text.ts
@@ -46,7 +46,7 @@ const command: Command = {
       composeEmbedMessage(msg, {
         usage: `${PREFIX}alert list`,
         examples: `${PREFIX}alert list`,
-        document: `${PRICE_ALERT_GITBOOK}`,
+        document: `${PRICE_ALERT_GITBOOK}&action=list`,
       }),
     ],
   }),

--- a/src/commands/alert/remove/text.ts
+++ b/src/commands/alert/remove/text.ts
@@ -73,7 +73,7 @@ const command: Command = {
       composeEmbedMessage(msg, {
         usage: `${PREFIX}alert remove`,
         examples: `${PREFIX}alert remove`,
-        document: `${PRICE_ALERT_GITBOOK}`,
+        document: `${PRICE_ALERT_GITBOOK}&action=remove`,
       }),
     ],
   }),

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -117,6 +117,7 @@ export const slashCommands: Record<string, SlashCommand> = {
   xprole: xprole.slashCmd,
   mixrole: mixrole.slashCmd,
   alert: alert.slashCmd,
+  wallet: wallet.slashCmd,
 }
 
 export const originalCommands: Record<string, Command> = {

--- a/src/commands/wallet/index.ts
+++ b/src/commands/wallet/index.ts
@@ -1,9 +1,15 @@
-import { Command } from "types/common"
-import { composeEmbedMessage } from "ui/discord/embed"
-import { PREFIX } from "utils/constants"
+import { Command, SlashCommand } from "types/common"
+import { composeEmbedMessage, composeEmbedMessage2 } from "ui/discord/embed"
+import { PREFIX, SLASH_PREFIX, WALLET_GITBOOK } from "utils/constants"
 import view from "./view/text"
 import add from "./add/text"
 import remove from "./remove/text"
+import viewSlash from "./view/slash"
+import {
+  SlashCommandBuilder,
+  SlashCommandSubcommandBuilder,
+} from "@discordjs/builders"
+import { CommandInteraction } from "discord.js"
 
 const actions: Record<string, Command> = {
   view,
@@ -35,4 +41,36 @@ const textCmd: Command = {
   allowDM: true,
 }
 
-export default { textCmd }
+const slashActions: Record<string, SlashCommand> = {
+  view: viewSlash,
+}
+
+const slashCmd: SlashCommand = {
+  name: "wallet",
+  category: "Defi",
+  prepare: () => {
+    const data = new SlashCommandBuilder()
+      .setName("wallet")
+      .setDescription("Track assets and activities of any on-chain wallet.")
+    data.addSubcommand(<SlashCommandSubcommandBuilder>viewSlash.prepare())
+    return data
+  },
+  run: (interaction: CommandInteraction) => {
+    return slashActions[interaction.options.getSubcommand()].run(interaction)
+  },
+  help: async (interaction) => ({
+    embeds: [
+      composeEmbedMessage2(interaction, {
+        title: "On-chain Wallet Tracking",
+        usage: `${SLASH_PREFIX}wallet <action>`,
+        examples: `${SLASH_PREFIX}wallet add 0xfBe6403a719d0572Ea4BA0E1c01178835b1D3bE4 mywallet\n${SLASH_PREFIX}wallet view`,
+        description: "Track assets and activities of any on-chain wallet.",
+        includeCommandsList: true,
+        document: WALLET_GITBOOK,
+      }),
+    ],
+  }),
+  colorType: "Defi",
+}
+
+export default { textCmd, slashCmd }

--- a/src/commands/wallet/view/slash.ts
+++ b/src/commands/wallet/view/slash.ts
@@ -1,1 +1,44 @@
-// TODO: slash
+import { SlashCommandSubcommandBuilder } from "@discordjs/builders"
+import { CommandInteraction } from "discord.js"
+import { SlashCommand } from "types/common"
+import { composeEmbedMessage2 } from "ui/discord/embed"
+import { SLASH_PREFIX, WALLET_GITBOOK } from "utils/constants"
+import { viewWalletDetails, viewWalletsList } from "./processor"
+
+const command: SlashCommand = {
+  name: "view",
+  category: "Defi",
+  prepare: () => {
+    return new SlashCommandSubcommandBuilder()
+      .setName("view")
+      .setDescription("Show all your interested wallets assets and activities.")
+      .addStringOption((option) =>
+        option
+          .setName("address")
+          .setDescription(
+            "The address or alias of the wallet you want to track"
+          )
+          .setRequired(false)
+      )
+  },
+  run: async (interaction) => {
+    const author = interaction.user
+    const address = interaction.options.getString("address", false)
+    if (address) {
+      return await viewWalletDetails(interaction, author, address)
+    }
+    return await viewWalletsList(interaction, author)
+  },
+  help: async (interaction: CommandInteraction) => ({
+    embeds: [
+      composeEmbedMessage2(interaction, {
+        usage: `${SLASH_PREFIX}wallet view [address]/[alias]`,
+        examples: `${SLASH_PREFIX}wallet view\n${SLASH_PREFIX}wallet view 0xfBe6403a719d0572Ea4BA0E1c01178835b1D3bE4\n${SLASH_PREFIX}wallet view mywallet`,
+        document: `${WALLET_GITBOOK}&action=view`,
+      }),
+    ],
+  }),
+  colorType: "Server",
+}
+
+export default command

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -216,7 +216,8 @@ export const STATEMENT_GITBOOK =
   "&command=statement"
 export const PRICE_ALERT_GITBOOK =
   USAGE_STATS_URL +
-  "https://mochibot.gitbook.io/mochi-bot/functions/crypto-management/price-alert"
+  "https://mochibot.gitbook.io/mochi-bot/functions/crypto-management/price-alert" +
+  "&command=alert"
 
 export const FTMSCAN_API = "https://api.ftmscan.com/api"
 export const BSCSCAN_API = "https://api.bscscan.com/api"


### PR DESCRIPTION
**What does this PR do?**

-   [x] Refactor wallet view to slash command

**How to test**

- Use `/wallet` or `/wallet view`


**Media (Loom or gif)**

<img width="636" alt="CleanShot 2023-02-24 at 17 25 39@2x" src="https://user-images.githubusercontent.com/14150687/221155312-aa5b7c55-aaca-41f8-8e19-3772a20d7ac0.png">
