### PR TITLE
fix: parse ticker args

### DIFF
--- a/src/utils/defi.ts
+++ b/src/utils/defi.ts
@@ -3,43 +3,23 @@ import { getAuthor } from "./common"
 import defi from "adapters/defi"
 import { InsufficientBalanceError } from "errors/insufficient-balance"
 
-const allowedFiats = ["gbp", "usd", "eur", "sgd", "vnd"]
-
-export function parseFiatQuery(q: string): string[] {
-  q = q.toLowerCase()
-  // normal format (e.g. usd/vnd)
-  if (q.includes("/")) {
-    const [base, target] = q.split("/")
-    if (!allowedFiats.includes(base) || !allowedFiats.includes(target)) {
-      return []
-    }
-    return [base, target]
-  }
-  // simplified format (e.g. eursgd)
-  const base = allowedFiats.filter((f) => q.startsWith(f))[0]
-  if (!base) return []
-  // check if target is specified. else fallback to "usd" (e.g. gbp)
-  const target = q.substring(base.length) ? q.substring(base.length) : "usd"
-  // validate
-  if (base === target) return []
-  return [base, target]
-}
-
 export function parseTickerQuery(q: string) {
+  const fiats = ["gbp", "usd", "eur", "sgd", "vnd"]
   q = q.toLowerCase()
   let isCompare = false
   let isFiat = false
   let [base, target] = q.split("/")
   if (target) {
     isCompare = true
-    isFiat = allowedFiats.includes(base) && allowedFiats.includes(target)
+    isFiat = fiats.includes(base) && fiats.includes(target)
   } else {
-    const fiatBase = allowedFiats.find((f) => q.startsWith(f))
+    const fiatBase = fiats.find((f) => q.startsWith(f))
     if (fiatBase) {
-      base = fiatBase
-      target = q.substring(base.length) || "usd"
-      isCompare = true
-      isFiat = true
+      const fiatTarget = q.substring(fiatBase.length) || "usd"
+      isFiat = fiats.includes(fiatBase) && fiats.includes(fiatTarget)
+      base = isFiat ? fiatBase : q
+      target = isFiat ? fiatTarget : ""
+      isCompare = isFiat
     }
   }
   return { isCompare, isFiat, base, target }


### PR DESCRIPTION
**What does this PR do?**
-   [x] case fiat: check if both base & target belongs to our supported fiats. if not => not comparison query => no target
