### PR TITLE
fix: dao voting checking msg

### DIFF
--- a/src/commands/proposal/processor.ts
+++ b/src/commands/proposal/processor.ts
@@ -519,7 +519,7 @@ export async function handleProposalVote(i: ButtonInteraction) {
         embeds: [
           getErrorEmbed({
             title: "Insufficient token amount",
-            description: `You need to own ${wData.vote_config.required_amount} **${wData.vote_config.symbol}** to vote for the proposal. `,
+            description: `You need to own **${wData.vote_config.symbol}** to vote for the proposal. `,
           }),
         ],
       })


### PR DESCRIPTION
**What does this PR do?**

-   [x] Remove the required amount of token msg, since user just need to own the token
