### PR TITLE
feat: redirect pay with recipient command to tip command

### DIFF
--- a/src/commands/pay/index.ts
+++ b/src/commands/pay/index.ts
@@ -3,6 +3,7 @@ import { composeEmbedMessage } from "ui/discord/embed"
 import { PREFIX } from "utils/constants"
 import link from "./link/text"
 import me from "./me/text"
+import tip from "../new-tip/index/text"
 
 const actions: Record<string, Command> = {
   link,
@@ -14,7 +15,7 @@ const textCmd: Command = {
   command: "pay",
   brief: "Finish all due payments right in Discord",
   category: "Defi",
-  run: async () => null,
+  run: tip,
   getHelpMessage: async (msg) => ({
     embeds: [
       composeEmbedMessage(msg, {
@@ -27,7 +28,7 @@ const textCmd: Command = {
   }),
   actions,
   colorType: "Wallet",
-  canRunWithoutAction: false,
+  canRunWithoutAction: true,
   allowDM: true,
 }
 


### PR DESCRIPTION
**What does this PR do?**

-   [x] When use uses `$pay` command with recipient, treat that as a `$tip` command

**How to test**
`$pay @user 1 ftm`
`$pay @role 1 ftm`
`$pay voice 1 ftm`

**Media (Loom or gif)**
<img width="526" alt="CleanShot 2023-04-05 at 12 02 18@2x" src="https://user-images.githubusercontent.com/25856620/229985554-75b5f80f-d675-477b-966e-d961fa524fab.png">
<img width="399" alt="CleanShot 2023-04-05 at 12 02 26@2x" src="https://user-images.githubusercontent.com/25856620/229985484-a91febb1-c095-4496-9cb0-5c04e76a235b.png">
<img width="601" alt="CleanShot 2023-04-05 at 12 02 22@2x" src="https://user-images.githubusercontent.com/25856620/229985496-b3964183-6b2e-432e-929b-4d8170949772.png">
