### PR TITLE
refactor: migrate wallet verification

### DIFF
--- a/src/adapters/profile.ts
+++ b/src/adapters/profile.ts
@@ -134,6 +134,13 @@ class Profile extends Fetcher {
       }
     )
   }
+
+  public async requestProfileCode(profileId: string) {
+    return await this.jsonFetch(
+      `${MOCHI_PROFILE_API_BASE_URL}/profiles/${profileId}/codes`,
+      { method: "POST" }
+    )
+  }
 }
 
 export default new Profile()

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -845,6 +845,11 @@ export interface RequestAddTokenPriceAlertRequest {
   value?: number;
 }
 
+export interface RequestAssignVerifiedRoleRequest {
+  guild_id: string;
+  user_discord_id: string;
+}
+
 export interface RequestBalcklistChannelRepostConfigRequest {
   channel_id?: string;
   guild_id?: string;
@@ -1431,6 +1436,8 @@ export interface ResponseCoinMarketItemData {
   image?: string;
   is_default?: boolean;
   is_pair?: boolean;
+  market_cap?: number;
+  market_cap_rank?: number;
   name?: string;
   price_change_percentage_24h?: number;
   price_change_percentage_7d_in_currency?: number;
@@ -1678,6 +1685,10 @@ export interface ResponseGetCoinResponse {
 
 export interface ResponseGetCoinResponseWrapper {
   data?: ResponseGetCoinResponse;
+}
+
+export interface ResponseGetCoinsMarketDataResponse {
+  data?: ResponseCoinMarketItemData[];
 }
 
 export interface ResponseGetCollectionCountResponse {


### PR DESCRIPTION
**What does this PR do?**
Migrate wallet verification: use new mochi-profile [endpoint](https://api-develop.mochi-profile.console.so/swagger/index.html#/profiles/post_profiles__id__codes) `/api/v1/profiles/{id}/code`
- [x] verify in `$wallet add`
- [x] verify in verify channel
