### PR TITLE
feat: tagme command, turn unsub button to resub

### DIFF
--- a/src/handlers/tagme.ts
+++ b/src/handlers/tagme.ts
@@ -33,7 +33,7 @@ class Tagme {
       return
     }
 
-    if (!data.is_active) return
+    if (!data?.is_active) return
 
     user
       .send({
@@ -55,7 +55,7 @@ class Tagme {
               .setURL(msgURL),
             new MessageButton()
               .setStyle("SECONDARY")
-              .setCustomId(`unsubscribe-tagme_${user.id}_${guildId}`)
+              .setCustomId(`tagme_unsubscribe_${user.id}_${guildId}`)
               .setEmoji(getEmoji("X"))
               .setLabel("Unsubscribe from this guild")
           ),
@@ -66,13 +66,14 @@ class Tagme {
       })
   }
 
-  async unsubscribe(i: ButtonInteraction) {
+  async editSubscribeStatus(i: ButtonInteraction) {
     await i.deferUpdate()
-    const [, userId, guildId] = i.customId.split("_")
+    const [, action, userId, guildId] = i.customId.split("_")
+    const isActive = action === "subscribe"
     const { ok, log, error } = await community.upsertTagme({
       userId,
       guildId,
-      isActive: false,
+      isActive,
     })
     if (!ok) {
       logger.warn(
@@ -88,9 +89,12 @@ class Tagme {
           ...(gotoMessageBtn ? [gotoMessageBtn] : []),
           new MessageButton()
             .setStyle("SECONDARY")
-            .setLabel("Unsubscribed")
-            .setCustomId("unsubscribed")
-            .setDisabled(true)
+            .setLabel(isActive ? "Unsubscribe from this guild" : "Subscribe")
+            .setCustomId(
+              `tagme_${
+                isActive ? "unsubscribe" : "subscribe"
+              }_${userId}_${guildId}`
+            )
         ),
       ],
     })

--- a/src/listeners/discord/interactionCreate.ts
+++ b/src/listeners/discord/interactionCreate.ts
@@ -445,8 +445,8 @@ async function handleButtonInteraction(interaction: Interaction) {
     case i.customId.startsWith("treasurerRemove-rejected"):
       await handleTreasurerRemove(i)
       return
-    case i.customId.startsWith("unsubscribe-tagme"):
-      await tagme.unsubscribe(i)
+    case i.customId.startsWith("tagme"):
+      await tagme.editSubscribeStatus(i)
       return
     default: {
       return


### PR DESCRIPTION
**What does this PR do?**

-   [x] Make the unsub button become resub instead of disabling it

**Media (Loom or gif)**

![CleanShot 2023-04-11 at 17 57 26](https://user-images.githubusercontent.com/25856620/231140353-e60c0083-5f23-4c2c-99b6-1788ef5d87b2.gif)
