### PR TITLE
chore: add alias watchlist view

### DIFF
--- a/src/commands/watchlist/index.ts
+++ b/src/commands/watchlist/index.ts
@@ -20,6 +20,7 @@ import addNFTSlash from "./add-nft/slash"
 import removeSlash from "./remove/slash"
 import removeNFTSlash from "./remove-nft/slash"
 import viewSlash from "./view/slash"
+import { getCommandArguments } from "utils/commands"
 
 CacheManager.init({
   ttl: 0,
@@ -40,7 +41,17 @@ const textCmd: Command = {
   command: "watchlist",
   brief: "Watchlist",
   category: "Defi",
-  run: async () => null,
+  run: async function (msg, ...rest) {
+    const [actionAlias] = getCommandArguments(msg)
+    switch (actionAlias) {
+      case "wlv":
+        return actions.view.run(msg, ...rest)
+      default:
+        return {
+          messageOptions: await this.getHelpMessage(msg, ...rest),
+        }
+    }
+  },
   featured: {
     title: `${getEmoji("search")} Watchlist`,
     description: "Manage your watchlist for selected tokens",
@@ -61,12 +72,12 @@ const textCmd: Command = {
       }),
     ],
   }),
-  canRunWithoutAction: false,
+  canRunWithoutAction: true,
+  minArguments: 1,
   allowDM: true,
   colorType: "Defi",
-  minArguments: 2,
   actions,
-  aliases: ["wl"],
+  aliases: ["wl", "wlv"],
 }
 
 const slashActions: Record<string, SlashCommand> = {


### PR DESCRIPTION
**What does this PR do?**

-   [x] Add `$wlv` as alias to `$wl view`

**Note**
We can not simply add alias to the `watchlist/view/text.ts` file because our structure doesn't support alias in command's action, so we must add alias to the command root and then handle it in the command's run function