### PR TITLE
fix: airdrop - all option

### DIFF
--- a/src/commands/airdrop/index.ts
+++ b/src/commands/airdrop/index.ts
@@ -18,7 +18,7 @@ const slashCmd: SlashCommand = {
     return new SlashCommandBuilder()
       .setName("airdrop")
       .setDescription("Airdrop tokens for a specified number of users.")
-      .addNumberOption((option) =>
+      .addStringOption((option) =>
         option
           .setName("amount")
           .setDescription("amount you want to airdrop. Example: 5, all, etc.")

--- a/src/commands/airdrop/index/slash.ts
+++ b/src/commands/airdrop/index/slash.ts
@@ -2,7 +2,7 @@ import { CommandInteraction } from "discord.js"
 import { handleAirdrop } from "./processor"
 
 async function run(interaction: CommandInteraction) {
-  const amount = interaction.options.getNumber("amount", true)
+  const amount = interaction.options.getString("amount", true)
   const token = interaction.options.getString("token", true)
   const duration = interaction.options.getString("duration")
   const entries = interaction.options.getNumber("entries")

--- a/src/errors/base.ts
+++ b/src/errors/base.ts
@@ -2,6 +2,7 @@ import {
   CommandInteraction,
   Message,
   MessageComponentInteraction,
+  SelectMenuInteraction,
 } from "discord.js"
 import { logger } from "logger"
 import { getEmoji } from "utils/common"
@@ -30,7 +31,10 @@ export class BotBaseError extends Error {
     if (message) {
       const reply = (message.reply as ReplyFunc).bind(message)
       this.reply = async (...args) => {
-        if (message instanceof CommandInteraction) {
+        if (
+          message instanceof CommandInteraction ||
+          message instanceof SelectMenuInteraction
+        ) {
           const replyMsg = await message.editReply(...args).catch(() => null)
           if (!replyMsg) {
             reply(...args).catch(() => null)

--- a/src/errors/insufficient-balance.ts
+++ b/src/errors/insufficient-balance.ts
@@ -43,6 +43,6 @@ export class InsufficientBalanceError extends BotBaseError {
       ...this.params,
       author: this.author,
     })
-    this.reply?.({ embeds: [embed] })
+    this.reply?.({ embeds: [embed], components: [] })
   }
 }

--- a/src/utils/wrap-error.ts
+++ b/src/utils/wrap-error.ts
@@ -81,6 +81,12 @@ export async function wrapError(
         }
         error.handle?.()
         ChannelLogger.alertSlash(message, error).catch(catchAll)
+      } else if (message.isSelectMenu()) {
+        if (!(error instanceof BotBaseError)) {
+          error = new BotBaseError(message, e.message as string)
+        }
+        error.handle?.()
+        ChannelLogger.alert(message.message as Message, error).catch(catchAll)
       }
       // send command info to kafka
       try {


### PR DESCRIPTION
**What does this PR do?**
-   [x] some errors related to show token amount and usd value for case `airdrop all`
-   [x] can't show insufficient balance response due to slash unhandled select-menu
-   [x] /airdrop only allow to input amount as number