### PR TITLE
fix: ticker chart number

### DIFF
--- a/src/ui/canvas/chart.ts
+++ b/src/ui/canvas/chart.ts
@@ -1,8 +1,7 @@
 import { ChartJSNodeCanvas } from "chartjs-node-canvas"
-import { getGradientColor } from "./color"
-import "../chartjs/date-adapter"
-import { utils } from "ethers"
 import { formatDigit } from "utils/defi"
+import "../chartjs/date-adapter"
+import { getGradientColor } from "./color"
 
 const chartCanvas = new ChartJSNodeCanvas({ width: 700, height: 450 })
 
@@ -57,7 +56,7 @@ export async function renderChartImage({
           ? rounded
           : Number(rounded) < 0.01 || Number(rounded) > 1000000
           ? Number(rounded).toExponential()
-          : utils.commify(formatDigit(String(value)))
+          : formatDigit(String(value))
       },
     },
     grid: {


### PR DESCRIPTION
**What does this PR do?**
-   [x] for large number (more than 4 integer digits), format digit add commas between them (e.g. 200k = 200,000) so pass that value utils.commify() will cause error
