### PR TITLE
fix: tip edge cases

### DIFF
--- a/src/commands/airdrop/index/slash.ts
+++ b/src/commands/airdrop/index/slash.ts
@@ -1,6 +1,7 @@
 import { CommandInteraction } from "discord.js"
 import { airdrop } from "./processor"
 
-const run = async (interaction: CommandInteraction) => airdrop(interaction)
+const run = async (interaction: CommandInteraction) =>
+  await airdrop(interaction)
 
 export default run

--- a/src/commands/balances/index/processor.ts
+++ b/src/commands/balances/index/processor.ts
@@ -189,8 +189,11 @@ function switchView(
           //
           const tokenVal = convertString(amount, decimal)
           const usdVal = price * tokenVal
-          const value = formatDigit(tokenVal.toString())
-          const usdWorth = formatDigit(usdVal.toString(), 4)
+          const value = formatDigit({ value: tokenVal.toString() })
+          const usdWorth = formatDigit({
+            value: usdVal.toString(),
+            fractionDigits: 4,
+          })
           //
           totalWorth += usdVal
           const text = `${value} ${symbol}`
@@ -223,8 +226,11 @@ function switchView(
         const { name: tokenName, symbol, decimal, price, chain, native } = token
         const tokenVal = convertString(amount, decimal)
         const usdVal = price * tokenVal
-        const value = formatDigit(tokenVal.toString())
-        const usdWorth = formatDigit(usdVal.toString(), 4)
+        const value = formatDigit({ value: tokenVal.toString() })
+        const usdWorth = formatDigit({
+          value: usdVal.toString(),
+          fractionDigits: 4,
+        })
         totalWorth += usdVal
         if (tokenVal === 0) return
 
@@ -248,7 +254,9 @@ function switchView(
 
   embed.addFields({
     name: `Total (U.S dollar)`,
-    value: `${getEmoji("CASH")} \`$${formatDigit(totalWorth.toString())}\``,
+    value: `${getEmoji("CASH")} \`$${formatDigit({
+      value: totalWorth.toString(),
+    })}\``,
   })
   return embed
 }
@@ -268,8 +276,11 @@ export async function renderBalances(
       const { name: tokenName, symbol, decimal, price, chain, native } = token
       const tokenVal = convertString(amount, decimal)
       const usdVal = price * tokenVal
-      const value = formatDigit(tokenVal.toString())
-      const usdWorth = formatDigit(usdVal.toString(), 4)
+      const value = formatDigit({ value: tokenVal.toString() })
+      const usdWorth = formatDigit({
+        value: usdVal.toString(),
+        fractionDigits: 4,
+      })
       totalWorth += usdVal
       if (tokenVal === 0) return
 
@@ -305,7 +316,9 @@ export async function renderBalances(
   justifyEmbedFields(embed, 3)
   embed.addFields({
     name: `Estimated total (U.S dollar)`,
-    value: `${getEmoji("CASH")} \`$${formatDigit(totalWorth.toString())}\``,
+    value: `${getEmoji("CASH")} \`$${formatDigit({
+      value: totalWorth.toString(),
+    })}\``,
   })
 
   return {

--- a/src/commands/swap/index/processor.ts
+++ b/src/commands/swap/index/processor.ts
@@ -275,10 +275,14 @@ export async function render(
   const routes = await aggregateTradeRoute(routeSummary)
 
   const fromAmountFormatted = utils.commify(
-    formatDigit(utils.formatUnits(routeSummary.amountIn, tokenIn.decimals))
+    formatDigit({
+      value: utils.formatUnits(routeSummary.amountIn, tokenIn.decimals),
+    })
   )
   const toAmountFormatted = utils.commify(
-    formatDigit(utils.formatUnits(routeSummary.amountOut, tokenOut.decimals))
+    formatDigit({
+      value: utils.formatUnits(routeSummary.amountOut, tokenOut.decimals),
+    })
   )
 
   const fromEmo = getEmojiToken(from, false)
@@ -337,7 +341,7 @@ export async function render(
     {
       name: "From",
       value: `${fromEmo} ${fromAmountFormatted} ${from} \n\`$${utils.commify(
-        formatDigit(routeSummary.amountInUsd)
+        formatDigit({ value: routeSummary.amountInUsd })
       )}\``,
       inline: true,
     },
@@ -349,14 +353,16 @@ export async function render(
     {
       name: "To",
       value: `${toEmo} ${toAmountFormatted} ${to}\n\`$${utils.commify(
-        formatDigit(routeSummary.amountOutUsd)
+        formatDigit({ value: routeSummary.amountOutUsd })
       )}\``,
       inline: true,
     },
     {
       name: "Gas Fee",
       value: routeSummary.gasUsd
-        ? `${APPROX} \`$${utils.commify(formatDigit(routeSummary.gasUsd))}\``
+        ? `${APPROX} \`$${utils.commify(
+            formatDigit({ value: routeSummary.gasUsd })
+          )}\``
         : "Unknown",
       inline: true,
     },

--- a/src/commands/tip/index.ts
+++ b/src/commands/tip/index.ts
@@ -2,7 +2,7 @@ import { SlashCommandBuilder } from "@discordjs/builders"
 import { Command, SlashCommand } from "types/common"
 import { composeEmbedMessage } from "ui/discord/embed"
 import { getCommandArguments } from "utils/commands"
-import { emojis, getEmoji, getEmojiURL } from "utils/common"
+import { emojis, equalIgnoreCase, getEmoji, getEmojiURL } from "utils/common"
 import {
   PREFIX,
   SLASH_PREFIX,
@@ -178,7 +178,9 @@ const slashCmd: SlashCommand = {
     const users = i.options.getString("users", true).split(SPACES_REGEX)
     const amount = i.options.getNumber("amount", true).toString()
     const token = i.options.getString("token", true)
-    const each = (i.options.getString("each") || "") === "each" ? "each" : ""
+    const each = equalIgnoreCase(i.options.getString("each") || "", "each")
+      ? "each"
+      : ""
     const message = `"${i.options.getString("message") ?? ""}"`
 
     const args = ["tip", ...users, amount, token, each, message].filter((s) =>

--- a/src/commands/tip/mail/processor.ts
+++ b/src/commands/tip/mail/processor.ts
@@ -293,7 +293,10 @@ async function validateAndTransfer(
 
   // proceed to transfer
   payload.chain_id = balance.token?.chain?.chain_id
-  payload.amount_string = formatDigit(payload.amount.toString(), decimal)
+  payload.amount_string = formatDigit({
+    value: payload.amount.toString(),
+    fractionDigits: decimal,
+  })
   payload.usd_amount = usdAmount
   return execute(msgOrInteraction, payload)
 }

--- a/src/commands/tip/telegram/processor.ts
+++ b/src/commands/tip/telegram/processor.ts
@@ -298,7 +298,10 @@ async function validateAndTransfer(
 
   // proceed to transfer
   payload.chain_id = balance.token?.chain?.chain_id
-  payload.amount_string = formatDigit(payload.amount.toString(), decimal)
+  payload.amount_string = formatDigit({
+    value: payload.amount.toString(),
+    fractionDigits: decimal,
+  })
   payload.usd_amount = usdAmount
   return execute(msgOrInteraction, payload)
 }

--- a/src/commands/tip/twitter/processor.ts
+++ b/src/commands/tip/twitter/processor.ts
@@ -286,7 +286,10 @@ async function validateAndTransfer(
 
   // proceed to transfer
   payload.chain_id = balance.token?.chain?.chain_id
-  payload.amount_string = formatDigit(payload.amount.toString(), decimal)
+  payload.amount_string = formatDigit({
+    value: payload.amount.toString(),
+    fractionDigits: decimal,
+  })
   payload.usd_amount = usdAmount
   return execute(msgOrInteraction, payload)
 }

--- a/src/commands/withdraw/index/processor.ts
+++ b/src/commands/withdraw/index/processor.ts
@@ -152,7 +152,10 @@ export async function withdraw(
         error: ` ${payload.token} valid amount must not have more than ${decimal} fractional digits. Please try again!`,
       })
     }
-    payload.amount_string = formatDigit(amount.toString(), decimal)
+    payload.amount_string = formatDigit({
+      value: amount.toString(),
+      fractionDigits: decimal,
+    })
     payload.chainId = balance.token?.chain?.chain_id
     await executeWithdraw(msgOrInteraction, payload)
     return
@@ -245,7 +248,10 @@ async function selectTokenToWithdraw(
       })
     }
     payload.amount = payload.amount.toString()
-    payload.amount_string = formatDigit(payload.amount.toString(), decimal)
+    payload.amount_string = formatDigit({
+      value: payload.amount.toString(),
+      fractionDigits: decimal,
+    })
     await executeWithdraw(msgOrInteraction, payload)
   }
 

--- a/src/types/transfer.ts
+++ b/src/types/transfer.ts
@@ -18,6 +18,7 @@ export type TransferPayload = {
   usd_amount?: number
   amount_string?: string
   token_price?: number
+  decimal?: number
 }
 
 export type AirdropOptions = { duration: number; entries?: number | null }

--- a/src/ui/canvas/chart.ts
+++ b/src/ui/canvas/chart.ts
@@ -56,7 +56,7 @@ export async function renderChartImage({
           ? rounded
           : Number(rounded) < 0.01 || Number(rounded) > 1000000
           ? Number(rounded).toExponential()
-          : formatDigit(String(value))
+          : formatDigit({ value: String(value) })
       },
     },
     grid: {

--- a/src/utils/defi.ts
+++ b/src/utils/defi.ts
@@ -6,11 +6,21 @@ import { getAuthor, TokenEmojiKey } from "./common"
 import { convertString } from "./convert"
 import { getProfileIdByDiscord } from "./profile"
 
-export function formatDigit(str: string, fractionDigits = 6) {
-  const num = Number(str)
+export function formatDigit({
+  value,
+  fractionDigits = 6,
+  withoutCommas = false,
+}: {
+  value: string
+  fractionDigits?: number
+  withoutCommas?: boolean
+}) {
+  const num = Number(value)
   const s = num.toLocaleString(undefined, { maximumFractionDigits: 18 })
   const [left, right = ""] = s.split(".")
-  if (Number(right) === 0 || right === "" || left.length >= 4) return left
+  if (Number(right) === 0 || right === "" || left.length >= 4) {
+    return withoutCommas ? left.replaceAll(",", "") : left
+  }
   const numsArr = right.split("")
   let rightStr = numsArr.shift() as string
   while (Number(rightStr) === 0 || rightStr.length < fractionDigits) {
@@ -22,11 +32,12 @@ export function formatDigit(str: string, fractionDigits = 6) {
   while (rightStr.endsWith("0")) {
     rightStr = rightStr.slice(0, rightStr.length - 1)
   }
-  return left + "." + rightStr
+  const leftStr = withoutCommas ? left.replaceAll(",", "") : left
+  return leftStr + "." + rightStr
 }
 
 export function isValidTipAmount(str: string, decimal: number) {
-  const s = formatDigit(str, decimal)
+  const s = formatDigit({ value: str, fractionDigits: decimal })
   if (s === "0") return false
   const numOfFracDigits = s.split(".")[1]?.length ?? 0
   return numOfFracDigits <= decimal


### PR DESCRIPTION
**What does this PR do?**
Handle tip/airdrop edge cases
- [x] $tip + $airdrop: prevent users from inputting too low amount
$tip
![image](https://user-images.githubusercontent.com/34529672/236787654-b6e7846c-b98b-446c-92d3-3ae69b807388.png)
$airdrop
![image](https://user-images.githubusercontent.com/34529672/236788175-ff46b0fa-5793-4a27-a204-6b8ad945ef04.png)


- [x] $tip: check if amount for each recipient is too low as well (e.g. 1e-18 ftm for 1 person is valid, but invalid for 2 people)
![image](https://user-images.githubusercontent.com/34529672/236786876-f4a18257-6c3f-42d5-8f64-8495de1a1163.png)

- [x] $airdrop
  - if `maxEntries` is specified, calculate max recipients and check if `maxEntries` exceed that  
![image](https://user-images.githubusercontent.com/34529672/236788400-5a1e8950-cc79-41af-974f-16cb73a223db.png)

  - if `maxEntries` is not specified, implicitly calculate maxRecipients and only send tokens to first `maxRecipients` participants
in the video, `maxEntries` was not specified but the amount can only splitted to at max 1 recipient -> airdrop session auto ended
https://user-images.githubusercontent.com/34529672/236790714-8b9dc117-fcbb-4cd8-bc9b-c68cbfc702e7.mov

- [x] truncate amount's decimals based on token decimals: e.g. 1.1e-18 -> 1e-18
![image](https://user-images.githubusercontent.com/34529672/236791774-d5998a7b-0304-430a-91e7-69f18ac5a90d.png)

- [x] /tip: `each` is now a boolean option
![image](https://user-images.githubusercontent.com/34529672/236792856-72ac8e8a-191e-4c2a-951e-11ef2e2c85b3.png)
