### PR TITLE
feat: change withdraw message dm user

### DIFF
--- a/src/commands/withdraw/index/processor.ts
+++ b/src/commands/withdraw/index/processor.ts
@@ -21,6 +21,7 @@ import {
   isAddress,
   isValidAmount,
   msgColors,
+  thumbnails,
 } from "utils/common"
 import {
   MOCHI_ACTION_WITHDRAW,
@@ -161,25 +162,13 @@ export async function withdraw(
   await selectTokenToWithdraw(msgOrInteraction, balances, payload, all)
 }
 
-function composeWithdrawEmbed(payload: any) {
-  const token = payload.token?.toUpperCase() ?? ""
-  const tokenEmoji = getEmoji(token)
+function composeWithdrawEmbed() {
   return composeEmbedMessage(null, {
-    author: ["Withdraw Order Submitted", getEmojiURL(emojis.CHECK)],
-    description: "Your withdrawal was processed succesfully!",
-    color: msgColors.MOCHI,
-  }).addFields(
-    {
-      name: `Recipient's ${token} Address`,
-      value: `\`\`\`${payload.address}\`\`\``,
-      inline: false,
-    },
-    {
-      name: "Recipient amount",
-      value: `${tokenEmoji} ${payload.amount} ${token}`,
-      inline: true,
-    }
-  )
+    author: ["Withdraw Submitted", thumbnails.MOCHI],
+    image: thumbnails.MOCHI_POSE_4,
+    description:
+      "Your withdraw is underway, Mochi will DM you with the tx link if it succeeds or error message if it fails",
+  })
 }
 
 async function selectTokenToWithdraw(
@@ -313,7 +302,7 @@ export async function executeWithdraw(
   kafkaMsg.activity.content.token = payload.token
   sendActivityMsg(kafkaMsg)
 
-  const embed = composeWithdrawEmbed(payload)
+  const embed = composeWithdrawEmbed()
   await author.send({ embeds: [embed] }).catch(() => {
     msgOrInteraction.reply({
       embeds: [enableDMMessage()],


### PR DESCRIPTION
**What does this PR do?**

-   [x] change message dm to user when withdrawal

From:
<img width="431" alt="Screen Shot 2023-05-09 at 10 21 49 AM" src="https://user-images.githubusercontent.com/39359294/236985673-5a43421b-ab96-451f-96d7-d71b64d5a276.png">
To:
<img width="428" alt="Screen Shot 2023-05-09 at 10 22 06 AM" src="https://user-images.githubusercontent.com/39359294/236985707-380fd223-5db8-4d1e-9fb0-739e16b98936.png">
<img width="644" alt="Screen Shot 2023-05-09 at 10 24 04 AM" src="https://user-images.githubusercontent.com/39359294/236985981-2672c365-1fac-4f8f-bee4-27f36ac590d1.png">

