### PR TITLE
fix: token add - handle errors

### DIFF
--- a/src/errors/internal.ts
+++ b/src/errors/internal.ts
@@ -1,6 +1,7 @@
 import { ColorResolvable } from "discord.js"
 import { getErrorEmbed } from "ui/discord/embed"
 import { BotBaseError, OriginalMessage } from "./base"
+import { msgColors } from "../utils/common"
 
 export class InternalError extends BotBaseError {
   private _customDescription: string | undefined
@@ -28,7 +29,7 @@ export class InternalError extends BotBaseError {
     this.name = title ?? "Internal error"
     this._customDescription = description
     this.emojiUrl = emojiUrl
-    this.color = color
+    this.color = color ?? msgColors.GRAY
   }
 
   handle() {


### PR DESCRIPTION
**What does this PR do?**
-   [x] `/token add`: Handle errors when token already exists or token data not found

**Media**
![image](https://github.com/consolelabs/mochi-discord/assets/34529672/ee29ecc9-d0b4-43fa-9474-e7f693195993)
![image](https://github.com/consolelabs/mochi-discord/assets/34529672/d169897c-9bba-46df-b3da-8f2eadf490b4)
