### PR TITLE
feat: enhance big number formatter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ process.on("SIGTERM", () => {
 const body = Object.entries(slashCommands ?? {}).map((e) =>
   e[1].prepare(e[0]).toJSON()
 )
-export const rest = new REST({ version: "9" }).setToken(DISCORD_TOKEN)
+const rest = new REST({ version: "9" }).setToken(DISCORD_TOKEN)
 ;(async () => {
   try {
     logger.info("Started refreshing application (/) commands.")

--- a/src/utils/commands.ts
+++ b/src/utils/commands.ts
@@ -1,11 +1,10 @@
 import { ApplicationCommandOptionType, Routes } from "discord-api-types/v9"
 import { CommandInteraction, Message } from "discord.js"
 import getEmojiRegex from "emoji-regex"
-import { APPLICATION_ID } from "env"
+import { APPLICATION_ID, DISCORD_TOKEN } from "env"
 
 import { utils } from "ethers"
 import { Command, SlashCommand, embedsColors } from "types/common"
-import { rest } from ".."
 import { getEmoji } from "./common"
 import {
   ANIMATED_EMOJI_REGEX,
@@ -18,10 +17,11 @@ import {
   SPACES_REGEX,
   USER_REGEX,
 } from "./constants"
+import { REST } from "@discordjs/rest"
 
 const NATIVE_EMOJI_REGEX = getEmojiRegex()
 
-// const rest = new REST({ version: "9" }).setToken(DISCORD_TOKEN)
+const rest = new REST({ version: "9" }).setToken(DISCORD_TOKEN)
 let cacheSlash = new Map<string, string>()
 
 export async function getSlashCommand(name: string) {


### PR DESCRIPTION
**What does this PR do?**
-   [x] Enhance `formatDigit()`: add flag `shorten` (bool). When enabled (true), shorten big number
    .e.g 
- 3000 -> 3K
- 2,512,534,123 -> 2.5B
- 1,000,000 -> 1M
- 4,111,111,111,111 -> 4.1T