### PR TITLE
fix: cover case ticker swap

### DIFF
--- a/src/commands/swap/index.ts
+++ b/src/commands/swap/index.ts
@@ -39,7 +39,6 @@ const slashCmd: SlashCommand = {
           .setDescription("the chain name")
           .setRequired(true)
           .setChoices([
-            ["solana", "solana"],
             ...Object.values(chains).map<[string, string]>((c) => [c, c]),
           ])
       )


### PR DESCRIPTION
This PR cover most of case for ticker swap

- On evm -> already handle case token exist on multiple chain, ex: usdc on eth, ftm, arb, ...
- [x] swap native -> non-native
<img width="449" alt="image" src="https://github.com/consolelabs/mochi-discord/assets/39881166/8839d227-07f9-4836-82e2-715247e09fa7">

- [x] swap non-native -> native
<img width="372" alt="image" src="https://github.com/consolelabs/mochi-discord/assets/39881166/8f220322-95c2-48cb-9aa5-545d5b818dc7">
<img width="377" alt="image" src="https://github.com/consolelabs/mochi-discord/assets/39881166/75fad902-8ee4-43af-801c-6c7119fa6101">
<img width="374" alt="image" src="https://github.com/consolelabs/mochi-discord/assets/39881166/4b09a40a-a40a-433d-9393-fb8ca4dce072">

- [x] swap some stupid / unsupported coin
<img width="465" alt="image" src="https://github.com/consolelabs/mochi-discord/assets/39881166/147ebe97-ac56-4901-a12f-6d8ab43dac3b">


- Edge case
- [x] Case token on multiple chain, ex: spell on ftm, eth, arb, ... -> currently temp get chain which coingecko return. In this case ethereum. Which means
->  we cant swap to Spell on chain ftm right now
->  if choose swap from ftm -> spell on ethereum will return no route
<img width="451" alt="image" src="https://github.com/consolelabs/mochi-discord/assets/39881166/1258d8b7-7810-4e80-8fa2-f53063cf1f46">
<img width="448" alt="image" src="https://github.com/consolelabs/mochi-discord/assets/39881166/2d97bbeb-922c-4c9d-8994-184c683d6902">


