### PR TITLE
fix: rounding balances

### DIFF
--- a/src/commands/balances/index/processor.ts
+++ b/src/commands/balances/index/processor.ts
@@ -361,7 +361,7 @@ export function formatView(
         const usdVal = price * tokenVal
         const value = formatDigit({
           value: tokenVal.toString(),
-          fractionDigits: 4,
+          fractionDigits: tokenVal >= 100000 ? 0 : 2,
         })
         const usdWorth = formatDigit({
           value: usdVal.toString(),
@@ -415,7 +415,7 @@ export function formatView(
         const usdVal = price * tokenVal
         const value = formatDigit({
           value: tokenVal.toString(),
-          fractionDigits: 4,
+          fractionDigits: tokenVal >= 100000 ? 0 : 2,
         })
         const usdWorth = formatDigit({
           value: usdVal.toString(),

--- a/src/utils/defi.ts
+++ b/src/utils/defi.ts
@@ -31,6 +31,8 @@ export function formatDigit({
     rightStr += nextDigit
   }
 
+  rightStr = rightStr.slice(0, fractionDigits)
+
   while (rightStr.endsWith("0")) {
     rightStr = rightStr.slice(0, rightStr.length - 1)
   }


### PR DESCRIPTION
**What does this PR do?**
Rounding token amount in /balances
-   [x] 2 digits if < 100K
-   [x] 0 digits if >= 100K