### PR TITLE
chore: update type gen swagger and get by discord with avoiding amount

### DIFF
--- a/scripts/generate-types.js
+++ b/scripts/generate-types.js
@@ -5,7 +5,7 @@ const path = require("path");
 generateApi({
   name: "api.ts",
   output: path.resolve(process.cwd(), "./src/types/"),
-  url: "https://develop-api.mochi.pod.town/swagger/doc.json",
+  url: `${process.env.API_SERVER_HOST}/swagger/doc.json`,
   generateClient: false,
   silent: true,
 });

--- a/src/adapters/profile.ts
+++ b/src/adapters/profile.ts
@@ -216,13 +216,15 @@ class Profile extends Fetcher {
     return await res?.json()
   }
 
-  public async getByDiscord(discordId: string) {
+  public async getByDiscord(discordId: string, noFetchAmount = false) {
     return await CacheManager.get({
       pool: "profile-data",
       key: discordId,
       call: async () => {
         const res = await fetch(
-          `${MOCHI_PROFILE_API_BASE_URL}/profiles/get-by-discord/${discordId}`
+          `${MOCHI_PROFILE_API_BASE_URL}/profiles/get-by-discord/${discordId}?${
+            noFetchAmount ? "?no-fetch-amount=true" : ""
+          }}`
         )
 
         return await res?.json()

--- a/src/commands/verify/processor.ts
+++ b/src/commands/verify/processor.ts
@@ -21,7 +21,7 @@ export async function sendVerifyURL(interaction: ButtonInteraction) {
       `Please verify your wallet address by clicking the button below.`
     )
   // request profile code
-  const profileId = await getProfileIdByDiscord(interaction.user.id)
+  const profileId = await getProfileIdByDiscord(interaction.user.id, true)
   const { data, ok, curl, log } = await profile.requestProfileCode(profileId)
   if (!ok) {
     throw new APIError({

--- a/src/utils/profile.ts
+++ b/src/utils/profile.ts
@@ -1,8 +1,11 @@
 import profile from "../adapters/profile"
 import { APIError } from "../errors"
 
-export async function getProfileIdByDiscord(discordId: string) {
-  const pf = await profile.getByDiscord(discordId)
+export async function getProfileIdByDiscord(
+  discordId: string,
+  noFetchAmount = false
+) {
+  const pf = await profile.getByDiscord(discordId, noFetchAmount)
   if (pf.err) {
     throw new APIError({
       description: `[getByDiscord] API error with status ${pf.status_code}`,


### PR DESCRIPTION
**What does this PR do?**

-   [x] Use env to set generate api url instead of hardcode using dev api
![image](https://github.com/consolelabs/mochi-discord/assets/32956772/cf1f3122-ee4a-4966-9556-e3b84f91cd60)
-   [x] Add option `noFetchAmount` when calling api get by discord