### PR TITLE
fix: update ui for cmd wallet track and copy when success

### DIFF
--- a/src/commands/wallet/copy/processor.ts
+++ b/src/commands/wallet/copy/processor.ts
@@ -1,9 +1,16 @@
 import defi from "adapters/defi"
-import { BalanceType, renderBalances } from "commands/balances/index/processor"
-import { User } from "discord.js"
+import { User, MessageActionRow, MessageButton } from "discord.js"
 import { InternalError, OriginalMessage } from "errors"
-import { getEmoji, isAddress } from "utils/common"
+import {
+  getEmoji,
+  isAddress,
+  emojis,
+  getEmojiURL,
+  msgColors,
+  shortenHashOrAddress,
+} from "utils/common"
 import { WalletTrackingType } from ".."
+import { composeEmbedMessage } from "ui/discord/embed"
 
 export async function copyWallet(
   msg: OriginalMessage,
@@ -47,19 +54,71 @@ export async function copyWallet(
       description: "Couldn't copy wallet",
     })
   }
-  const { messageOptions } = await renderBalances(
-    author.id,
-    msg,
-    BalanceType.Onchain,
-    address
-  )
-
-  const iconURl = messageOptions.embeds[0].author?.iconURL
-  if (alias) {
-    messageOptions.embeds[0].setAuthor(alias, iconURl)
-  } else {
-    messageOptions.embeds[0].setAuthor("Wallet copied", iconURl)
-  }
+  const { messageOptions } = renderTrackingResult(msg, author.id, address)
 
   return messageOptions
+}
+
+function renderTrackingResult(
+  msg: OriginalMessage,
+  authorID: string,
+  address: string
+) {
+  return {
+    messageOptions: {
+      embeds: [
+        composeEmbedMessage(null, {
+          author: [
+            `${shortenHashOrAddress(
+              address
+            )} has been added to the watchlist to copy trades`,
+            getEmojiURL(emojis.CHECK),
+          ],
+          color: msgColors.SUCCESS,
+          description: `
+${getEmoji(
+  "ANIMATED_POINTING_RIGHT",
+  true
+)} View wallet watchlist by clicking on button \`Watchlist\`.
+${getEmoji(
+  "ANIMATED_POINTING_RIGHT",
+  true
+)} Follow this wallet by clicking on button \`Follow\`.
+${getEmoji(
+  "ANIMATED_POINTING_RIGHT",
+  true
+)} Track wallet's transactions by clicking on button \`Track\`.
+${getEmoji(
+  "ANIMATED_POINTING_RIGHT",
+  true
+)} To remove copy trade setting, click on button \`Uncopy\`.
+            `,
+        }),
+      ],
+      components: [
+        new MessageActionRow().addComponents(
+          new MessageButton()
+            .setLabel("Watchlist")
+            .setStyle("PRIMARY")
+            .setCustomId(`view_wallet`)
+            .setEmoji(emojis.PROPOSAL),
+          new MessageButton()
+            .setLabel("Follow")
+            .setStyle("SECONDARY")
+            .setCustomId(`follow_wallet-${authorID}-${address}`)
+            .setEmoji(emojis.PLUS),
+          new MessageButton()
+            .setLabel("Track")
+            .setStyle("SECONDARY")
+            .setCustomId(`track_wallet-${authorID}-${address}`)
+            .setEmoji(emojis.ANIMATED_STAR),
+          new MessageButton()
+            .setLabel("Uncopy")
+            .setStyle("SECONDARY")
+            .setCustomId(`uncopytrade_wallet-${authorID}-${address}`)
+            .setEmoji(emojis.REVOKE)
+        ),
+      ],
+    },
+  }
 }

--- a/src/commands/wallet/copy/slash.ts
+++ b/src/commands/wallet/copy/slash.ts
@@ -1,7 +1,36 @@
 import { SlashCommandSubcommandBuilder } from "@discordjs/builders"
-import { CommandInteraction } from "discord.js"
+import { CommandInteraction, Message } from "discord.js"
 import { SlashCommand } from "types/common"
 import { copyWallet } from "./processor"
+import { MachineConfig, route } from "utils/router"
+
+export const machineConfig: MachineConfig = {
+  id: "wallet-copy",
+  initial: "copy",
+  states: {
+    copy: {
+      on: {
+        VIEW_WALLET: "wallets",
+      },
+    },
+    wallets: {
+      id: "wallets",
+      initial: "wallets",
+      states: {
+        wallets: {
+          on: {
+            VIEW_WALLET: "wallet",
+          },
+        },
+        wallet: {
+          on: {
+            BACK: "wallets",
+          },
+        },
+      },
+    },
+  },
+}
 
 const command: SlashCommand = {
   name: "copy",
@@ -34,9 +63,16 @@ const command: SlashCommand = {
     const chain = i.options.getString("chain", false) ?? "eth"
     const alias = i.options.getString("alias", false) ?? ""
 
-    return {
-      messageOptions: await copyWallet(i, i.user, address, chain, alias),
-    }
+    const copytradeWalletResult = await copyWallet(
+      i,
+      i.user,
+      address,
+      chain,
+      alias
+    )
+    const reply = await i.editReply(copytradeWalletResult)
+
+    route(reply as Message, i.user, machineConfig)
   },
   help: () => Promise.resolve({}),
   colorType: "Defi",

--- a/src/commands/wallet/follow/processor.ts
+++ b/src/commands/wallet/follow/processor.ts
@@ -80,7 +80,7 @@ ${getEmoji(
 ${getEmoji(
   "ANIMATED_POINTING_RIGHT",
   true
-)} Tracking this wallet by clicking on button \`Track\`.
+)} Track this wallet's transaction by clicking on button \`Track\`.
 ${getEmoji(
   "ANIMATED_POINTING_RIGHT",
   true
@@ -97,22 +97,22 @@ ${getEmoji(
           new MessageButton()
             .setLabel("Watchlist")
             .setStyle("PRIMARY")
-            .setCustomId(`watchlist_wallets_view`)
+            .setCustomId(`view_wallet`)
             .setEmoji(emojis.PROPOSAL),
           new MessageButton()
             .setLabel("Track")
             .setStyle("SECONDARY")
-            .setCustomId(`watchlist_wallets_track-${authorID}-${address}`)
+            .setCustomId(`track_wallet-${authorID}-${address}`)
             .setEmoji(emojis.ANIMATED_STAR),
           new MessageButton()
             .setLabel("Copy")
             .setStyle("SECONDARY")
-            .setCustomId(`watchlist_wallets_copy-${authorID}-${address}`)
+            .setCustomId(`copytrade_wallet-${authorID}-${address}`)
             .setEmoji(emojis.SWAP_ROUTE),
           new MessageButton()
             .setLabel("Unfollow")
-            .setStyle("DANGER")
-            .setCustomId(`watchlist_wallets_unfollow-${authorID}-${address}`)
+            .setStyle("SECONDARY")
+            .setCustomId(`unfollow_wallet-${authorID}-${address}`)
             .setEmoji(emojis.REVOKE)
         ),
       ],

--- a/src/commands/wallet/follow/slash.ts
+++ b/src/commands/wallet/follow/slash.ts
@@ -1,7 +1,36 @@
 import { SlashCommandSubcommandBuilder } from "@discordjs/builders"
-import { CommandInteraction } from "discord.js"
+import { CommandInteraction, Message } from "discord.js"
 import { SlashCommand } from "types/common"
 import { followWallet } from "./processor"
+import { MachineConfig, route } from "utils/router"
+
+export const machineConfig: MachineConfig = {
+  id: "wallet-follow",
+  initial: "follow",
+  states: {
+    follow: {
+      on: {
+        VIEW_WALLET: "wallets",
+      },
+    },
+    wallets: {
+      id: "wallets",
+      initial: "wallets",
+      states: {
+        wallets: {
+          on: {
+            VIEW_WALLET: "wallet",
+          },
+        },
+        wallet: {
+          on: {
+            BACK: "wallets",
+          },
+        },
+      },
+    },
+  },
+}
 
 const command: SlashCommand = {
   name: "follow",
@@ -34,9 +63,16 @@ const command: SlashCommand = {
     const chain = i.options.getString("chain", false) ?? "eth"
     const alias = i.options.getString("alias", false) ?? ""
 
-    return {
-      messageOptions: await followWallet(i, i.user, address, chain, alias),
-    }
+    const followWalletResult = await followWallet(
+      i,
+      i.user,
+      address,
+      chain,
+      alias
+    )
+    const reply = await i.editReply(followWalletResult)
+
+    route(reply as Message, i.user, machineConfig)
   },
   help: () => Promise.resolve({}),
   colorType: "Defi",

--- a/src/commands/wallet/list/processor.ts
+++ b/src/commands/wallet/list/processor.ts
@@ -1,93 +1,13 @@
 import defi from "adapters/defi"
-import { BalanceType, renderBalances } from "commands/balances/index/processor"
-import {
-  Message,
-  MessageActionRow,
-  MessageButton,
-  MessageSelectMenu,
-  User,
-} from "discord.js"
+import { MessageActionRow, MessageSelectMenu, User } from "discord.js"
 import { ResponseGetTrackingWalletsResponse } from "types/api"
 import { composeEmbedMessage, formatDataTable } from "ui/discord/embed"
 import { getSlashCommand } from "utils/commands"
 import { emojis } from "utils/common"
 import { getEmojiURL } from "utils/common"
-import {
-  authorFilter,
-  getEmoji,
-  shortenHashOrAddress,
-  capitalizeFirst,
-} from "utils/common"
+import { getEmoji, shortenHashOrAddress, capitalizeFirst } from "utils/common"
 import { APPROX, VERTICAL_BAR } from "utils/constants"
 import { formatDigit } from "utils/defi"
-import { wrapError } from "utils/wrap-error"
-
-export function collectSelection(reply: Message, author: User) {
-  reply
-    .createMessageComponentCollector({
-      componentType: "SELECT_MENU",
-      filter: authorFilter(author.id),
-      time: 300000,
-    })
-    .on("collect", (i) => {
-      wrapError(reply, async () => {
-        if (!i.deferred) {
-          await i.deferUpdate().catch(() => null)
-        }
-        if (i.customId === "wallets_view-wallet") {
-          const [userId, address] = i.values[0].split("_")
-          const walletDetailView = await renderBalances(
-            userId,
-            i,
-            BalanceType.Onchain,
-            address
-          )
-          walletDetailView.messageOptions.components.unshift(
-            new MessageActionRow().addComponents(
-              new MessageButton()
-                .setLabel("Back")
-                .setStyle("SECONDARY")
-                .setCustomId("back")
-            )
-          )
-
-          const edited = (await i.editReply(
-            walletDetailView.messageOptions
-          )) as Message
-
-          edited
-            .createMessageComponentCollector({
-              componentType: "BUTTON",
-              filter: authorFilter(author.id),
-              time: 300000,
-            })
-            .on("collect", async (i) => {
-              if (!i.deferred) {
-                await i.deferUpdate().catch(() => null)
-              }
-              wrapError(reply, async () => {
-                if (i.customId === "back") {
-                  await i.editReply({
-                    embeds: reply.embeds,
-                    components: reply.components,
-                  })
-                }
-              })
-            })
-            .on("end", () => {
-              wrapError(reply, async () => {
-                await i.editReply({ components: [] }).catch(() => null)
-              })
-            })
-        }
-      })
-    })
-    .on("end", () => {
-      wrapError(reply, async () => {
-        await reply.edit({ components: [] }).catch(() => null)
-      })
-    })
-}
 
 const emojiMap = {
   following: getEmoji("PLUS"),
@@ -196,7 +116,7 @@ export async function render(user: User) {
           new MessageActionRow().addComponents(
             new MessageSelectMenu()
               .setPlaceholder("💰 View a wallet")
-              .setCustomId("wallets_view-wallet")
+              .setCustomId("view_wallet")
               .addOptions(options)
           ),
         ]

--- a/src/commands/wallet/track/slash.ts
+++ b/src/commands/wallet/track/slash.ts
@@ -1,10 +1,39 @@
 import { SlashCommandSubcommandBuilder } from "@discordjs/builders"
-import { CommandInteraction } from "discord.js"
+import { CommandInteraction, Message } from "discord.js"
 import { SlashCommand } from "types/common"
 import { trackWallet } from "./processor"
 import { composeEmbedMessage2 } from "ui/discord/embed"
 import { thumbnails } from "utils/common"
 import { SLASH_PREFIX } from "utils/constants"
+import { MachineConfig, route } from "utils/router"
+
+export const machineConfig: MachineConfig = {
+  id: "wallet-track",
+  initial: "track",
+  states: {
+    track: {
+      on: {
+        VIEW_WALLET: "wallets",
+      },
+    },
+    wallets: {
+      id: "wallets",
+      initial: "wallets",
+      states: {
+        wallets: {
+          on: {
+            VIEW_WALLET: "wallet",
+          },
+        },
+        wallet: {
+          on: {
+            BACK: "wallets",
+          },
+        },
+      },
+    },
+  },
+}
 
 const command: SlashCommand = {
   name: "track",
@@ -37,9 +66,16 @@ const command: SlashCommand = {
     const chain = i.options.getString("chain", false) ?? "eth"
     const alias = i.options.getString("alias", false) ?? ""
 
-    return {
-      messageOptions: await trackWallet(i, i.user, address, chain, alias),
-    }
+    const trackWalletResult = await trackWallet(
+      i,
+      i.user,
+      address,
+      chain,
+      alias
+    )
+    const reply = await i.editReply(trackWalletResult)
+
+    route(reply as Message, i.user, machineConfig)
   },
   help: (interaction) =>
     Promise.resolve({


### PR DESCRIPTION
**What does this PR do?**

-   [x] Update successful UI for cmd `/wallet track` and button to route to watchlist wallet
![image](https://github.com/consolelabs/mochi-discord/assets/32956772/55fb9637-2ebc-4026-8659-12213a48aa98)
![image](https://github.com/consolelabs/mochi-discord/assets/32956772/08819356-a463-4b49-81e2-789c551a9858)
-   [x] Update successful UI for cmd `/wallet copy` and button to route to watchlist wallet
![image](https://github.com/consolelabs/mochi-discord/assets/32956772/7c55392f-228c-4f7c-ae72-b6719f3f52f0)
![image](https://github.com/consolelabs/mochi-discord/assets/32956772/64aa8b66-036e-43ab-89f9-e52015e209ce)
