### PR TITLE
fix: format extremely small number

### DIFF
--- a/src/commands/ticker/index/processor.ts
+++ b/src/commands/ticker/index/processor.ts
@@ -188,6 +188,7 @@ export async function composeTickerResponse({
     : `$${formatDigit({
         value: String(current_price[currency]),
         fractionDigits: 2,
+        scientificFormat: true,
       })}`
   const marketCap = +market_cap[currency]
   const bb = getChance(20)

--- a/src/commands/watchlist/view/processor.ts
+++ b/src/commands/watchlist/view/processor.ts
@@ -443,6 +443,7 @@ export async function composeWatchlist(
             usd: `$${formatDigit({
               value: String(t.current_price ?? "0"),
               fractionDigits: 2,
+              scientificFormat: true,
             })}`,
           })),
           {

--- a/src/utils/defi.ts
+++ b/src/utils/defi.ts
@@ -12,15 +12,24 @@ export function formatDigit({
   fractionDigits = 6,
   withoutCommas = false,
   shorten = false,
+  scientificFormat = false,
 }: {
   value: string | number
   fractionDigits?: number
   withoutCommas?: boolean
   shorten?: boolean
+  scientificFormat?: boolean
 }) {
   const num = Number(String(value).replaceAll(COMMA, EMPTY))
+
   // invalid number -> keeps value the same and returns
   if (!num) return String(value)
+
+  // return shorten scientific number if original value is in scientific format . e.g. 1.123e-5
+  if (String(num).includes("e") && scientificFormat) {
+    return shortenScientificNotation({ value: String(num) })
+  }
+
   const s = num.toLocaleString(undefined, { maximumFractionDigits: 18 })
   const [left, right = ""] = s.split(".")
   const numsArr = right.split("")
@@ -116,4 +125,23 @@ export async function validateBalance({
 
 export function isNaturalNumber(n: number) {
   return n >= 0 && Math.floor(n) === n
+}
+
+export function shortenScientificNotation({
+  value,
+  maximumFractionDigits = 2,
+}: {
+  value: string | number
+  maximumFractionDigits?: number
+}): string {
+  const str = String(value)
+  if (!Number(str)) return str
+  if (!str.includes("e")) return str
+
+  const delemiterIdx = str.indexOf("e")
+  const leftStr = Number(str.slice(0, delemiterIdx)).toLocaleString(undefined, {
+    maximumFractionDigits,
+  })
+  const rightStr = str.slice(delemiterIdx)
+  return leftStr + rightStr
 }


### PR DESCRIPTION
**What does this PR do?**
-   [x] Handle super small number for token price: display in shorten (2 digits) scientific notation format
e.g. 
value: `2.828935807662611e-7`
Before:  show as `0`
Now: show as `2.83e-7`

**Media**
![image](https://github.com/consolelabs/mochi-discord/assets/34529672/ae166a72-df90-435d-9970-e9ab0e12acdd)
![image](https://github.com/consolelabs/mochi-discord/assets/34529672/d5729e3e-a99f-47a2-b745-8ef09d46775e)
