### PR TITLE
fix: wallet tracking flow mapping

### DIFF
--- a/src/commands/balances/index/processor.ts
+++ b/src/commands/balances/index/processor.ts
@@ -102,7 +102,7 @@ const balanceEmbedProps: Record<
       address,
       alias: wallet?.alias,
       title: `${wallet?.alias || shortenHashOrAddress(address)}'s wallet`,
-      emoji: getEmojiURL(emojis.WALLET_1),
+      emoji: getEmojiURL(emojis.WALLET_2),
       description: `${getEmoji(
         "ANIMATED_POINTING_RIGHT",
         true
@@ -674,16 +674,6 @@ export async function renderBalances(
         !isOwnWallet && type === BalanceType.Onchain
           ? [
               new MessageActionRow().addComponents(
-                new MessageButton()
-                  .setLabel("Copy trade")
-                  .setStyle("SECONDARY")
-                  .setEmoji(getEmoji("SWAP_ROUTE"))
-                  .setCustomId("balance_copy-trade"),
-                new MessageButton()
-                  .setLabel("Track")
-                  .setStyle("SECONDARY")
-                  .setCustomId("balance_track")
-                  .setEmoji(getEmoji("ANIMATED_STAR", true)),
                 isFollowed
                   ? new MessageButton()
                       .setLabel("Unfollow")
@@ -694,7 +684,17 @@ export async function renderBalances(
                       .setLabel("Follow")
                       .setStyle("SECONDARY")
                       .setCustomId("balance_follow")
-                      .setEmoji(getEmoji("PLUS"))
+                      .setEmoji(getEmoji("PLUS")),
+                new MessageButton()
+                  .setLabel("Track")
+                  .setStyle("SECONDARY")
+                  .setCustomId("balance_track")
+                  .setEmoji(getEmoji("ANIMATED_STAR", true)),
+                new MessageButton()
+                  .setLabel("Copy trade")
+                  .setStyle("SECONDARY")
+                  .setEmoji(getEmoji("SWAP_ROUTE"))
+                  .setCustomId("balance_copy-trade")
               ),
             ]
           : [

--- a/src/commands/wallet/common/tracking.ts
+++ b/src/commands/wallet/common/tracking.ts
@@ -3,6 +3,11 @@ import { copyWallet } from "../copy/processor"
 import { followWallet } from "../follow/processor"
 import { untrackWallet } from "../remove/processor"
 import { trackWallet } from "../track/processor"
+import { render as renderTrackingWallets } from "commands/wallet/list/processor"
+import {
+  BalanceType,
+  renderBalances as viewWalletDetail,
+} from "commands/balances/index/processor"
 
 export const machineConfig: (id: string, context?: any) => MachineConfig = (
   id,
@@ -19,13 +24,25 @@ export const machineConfig: (id: string, context?: any) => MachineConfig = (
       walletCopy: (i, _ev, ctx) =>
         copyWallet(i, i.user, ctx.address, ctx.chain, ctx.alias),
       walletUntrack: (i, _ev, ctx) => untrackWallet(i, i.user, ctx.address),
+      wallets: (i) => renderTrackingWallets(i.user),
+    },
+    select: {
+      wallet: async (i) => {
+        const [, , address = ""] = i.values[0].split("_")
+
+        return {
+          msgOpts: (
+            await viewWalletDetail(i.user.id, i, BalanceType.Onchain, address)
+          ).messageOptions,
+        }
+      },
     },
     ...context,
   },
   states: {
     walletFollow: {
       on: {
-        VIEW_WALLET: "wallets",
+        VIEW_WALLETS: "wallets",
         TRACK_WALLET: "walletTrack",
         COPY_WALLET: "walletCopy",
         UNTRACK_WALLET: "walletUntrack",
@@ -33,7 +50,7 @@ export const machineConfig: (id: string, context?: any) => MachineConfig = (
     },
     walletTrack: {
       on: {
-        VIEW_WALLET: "wallets",
+        VIEW_WALLETS: "wallets",
         FOLLOW_WALLET: "walletFollow",
         COPY_WALLET: "walletCopy",
         UNTRACK_WALLET: "walletUntrack",
@@ -41,7 +58,7 @@ export const machineConfig: (id: string, context?: any) => MachineConfig = (
     },
     walletCopy: {
       on: {
-        VIEW_WALLET: "wallets",
+        VIEW_WALLETS: "wallets",
         TRACK_WALLET: "walletTrack",
         FOLLOW_WALLET: "walletFollow",
         UNTRACK_WALLET: "walletUntrack",
@@ -49,23 +66,19 @@ export const machineConfig: (id: string, context?: any) => MachineConfig = (
     },
     walletUntrack: {
       on: {
-        VIEW_WALLET: "wallets",
+        VIEW_WALLETS: "wallets",
+      },
+    },
+    wallet: {
+      id: "wallet",
+      on: {
+        BACK: "wallets",
       },
     },
     wallets: {
       id: "wallets",
-      initial: "wallets",
-      states: {
-        wallets: {
-          on: {
-            VIEW_WALLET: "wallet",
-          },
-        },
-        wallet: {
-          on: {
-            BACK: "wallets",
-          },
-        },
+      on: {
+        VIEW_WALLET: "wallet",
       },
     },
   },

--- a/src/commands/wallet/copy/processor.ts
+++ b/src/commands/wallet/copy/processor.ts
@@ -99,10 +99,10 @@ ${getEmoji(
       components: [
         new MessageActionRow().addComponents(
           new MessageButton()
-            .setLabel("Watchlist")
+            .setLabel("Wallets")
             .setStyle("PRIMARY")
-            .setCustomId(`view_wallet`)
-            .setEmoji(emojis.PROPOSAL),
+            .setCustomId(`view_wallets`)
+            .setEmoji(emojis.WALLET_1),
           new MessageButton()
             .setLabel("Follow")
             .setStyle("SECONDARY")

--- a/src/commands/wallet/follow/processor.ts
+++ b/src/commands/wallet/follow/processor.ts
@@ -96,10 +96,10 @@ ${getEmoji(
       components: [
         new MessageActionRow().addComponents(
           new MessageButton()
-            .setLabel("Watchlist")
+            .setLabel("Wallets")
             .setStyle("PRIMARY")
-            .setCustomId(`view_wallet`)
-            .setEmoji(emojis.PROPOSAL),
+            .setCustomId(`view_wallets`)
+            .setEmoji(emojis.WALLET_1),
           new MessageButton()
             .setLabel("Track")
             .setStyle("SECONDARY")

--- a/src/commands/wallet/index.ts
+++ b/src/commands/wallet/index.ts
@@ -6,6 +6,7 @@ import add from "./add/slash"
 import track from "./track/slash"
 import follow from "./follow/slash"
 import copy from "./copy/slash"
+import list from "./list/slash"
 import {
   SlashCommandBuilder,
   SlashCommandSubcommandBuilder,
@@ -24,6 +25,7 @@ const slashActions: Record<string, SlashCommand> = {
   track,
   follow,
   copy,
+  list,
 }
 
 const slashCmd: SlashCommand = {
@@ -38,6 +40,7 @@ const slashCmd: SlashCommand = {
     data.addSubcommand(<SlashCommandSubcommandBuilder>track.prepare())
     data.addSubcommand(<SlashCommandSubcommandBuilder>follow.prepare())
     data.addSubcommand(<SlashCommandSubcommandBuilder>copy.prepare())
+    data.addSubcommand(<SlashCommandSubcommandBuilder>list.prepare())
     return data
   },
   autocomplete: function (i) {

--- a/src/commands/wallet/list/slash.ts
+++ b/src/commands/wallet/list/slash.ts
@@ -1,0 +1,27 @@
+import { SlashCommandSubcommandBuilder } from "@discordjs/builders"
+import { CommandInteraction, Message } from "discord.js"
+import { SlashCommand } from "types/common"
+import { route } from "utils/router"
+import { machineConfig } from "commands/wallet/common/tracking"
+import { render as renderTrackingWallets } from "./processor"
+
+const command: SlashCommand = {
+  name: "list",
+  category: "Defi",
+  prepare: () => {
+    return new SlashCommandSubcommandBuilder()
+      .setName("list")
+      .setDescription("Show all your interested wallets assets and activities.")
+  },
+  run: async function (i: CommandInteraction) {
+    const { msgOpts } = await renderTrackingWallets(i.user)
+
+    const reply = await i.editReply(msgOpts)
+
+    route(reply as Message, i, machineConfig("wallets", {}))
+  },
+  help: () => Promise.resolve({}),
+  colorType: "Defi",
+}
+
+export default command

--- a/src/commands/wallet/remove/processor.ts
+++ b/src/commands/wallet/remove/processor.ts
@@ -66,10 +66,10 @@ ${pointingright} Click \`Watchlist\` to view all tracked wallets.
   })
   const btnRow = new MessageActionRow().addComponents(
     new MessageButton()
-      .setLabel("Watchlist")
+      .setLabel("Wallets")
       .setStyle("PRIMARY")
-      .setCustomId(`view_wallet`)
-      .setEmoji(emojis.PROPOSAL)
+      .setCustomId(`view_wallets`)
+      .setEmoji(emojis.WALLET_1)
   )
   return { msgOpts: { embeds: [embed], components: [btnRow] } }
 }

--- a/src/commands/wallet/track/processor.ts
+++ b/src/commands/wallet/track/processor.ts
@@ -96,10 +96,10 @@ ${getEmoji(
       components: [
         new MessageActionRow().addComponents(
           new MessageButton()
-            .setLabel("Watchlist")
+            .setLabel("Wallets")
             .setStyle("PRIMARY")
-            .setCustomId(`view_wallet`)
-            .setEmoji(emojis.PROPOSAL),
+            .setCustomId(`view_wallets`)
+            .setEmoji(emojis.WALLET_1),
           new MessageButton()
             .setLabel("Follow")
             .setStyle("SECONDARY")

--- a/src/commands/wallet/view/slash.ts
+++ b/src/commands/wallet/view/slash.ts
@@ -1,10 +1,12 @@
 import { SlashCommandSubcommandBuilder } from "@discordjs/builders"
 import profile from "adapters/profile"
 import { BalanceType, renderBalances } from "commands/balances/index/processor"
-import { CommandInteraction } from "discord.js"
+import { CommandInteraction, Message } from "discord.js"
 import { SlashCommand } from "types/common"
 import { composeEmbedMessage2 } from "ui/discord/embed"
 import { SLASH_PREFIX, WALLET_GITBOOK } from "utils/constants"
+import { route } from "utils/router"
+import { machineConfig } from "commands/wallet/common/tracking"
 
 const command: SlashCommand = {
   name: "view",
@@ -12,7 +14,7 @@ const command: SlashCommand = {
   prepare: () => {
     return new SlashCommandSubcommandBuilder()
       .setName("view")
-      .setDescription("Show all your interested wallets assets and activities.")
+      .setDescription("Show the wallet's assets and activities.")
       .addStringOption((option) =>
         option
           .setName("address")
@@ -38,7 +40,7 @@ const command: SlashCommand = {
   run: async (interaction) => {
     const address = interaction.options.getString("address", true)
 
-    return await renderBalances(
+    const { messageOptions } = await renderBalances(
       // TODO: this id currently is wrong
       interaction.user.id,
       interaction,
@@ -46,6 +48,10 @@ const command: SlashCommand = {
       address,
       "compact"
     )
+
+    const reply = await interaction.editReply(messageOptions)
+
+    route(reply as Message, interaction, machineConfig("wallet", {}))
   },
   help: (interaction: CommandInteraction) =>
     Promise.resolve({

--- a/src/commands/watchlist/view/processor.ts
+++ b/src/commands/watchlist/view/processor.ts
@@ -28,7 +28,7 @@ export function buildSwitchViewActionRow(currentView: string) {
     disabled: currentView === "nft",
   })
   const viewWalletBtn = new MessageButton({
-    label: "Wallet",
+    label: "Wallets",
     emoji: getEmoji("WALLET_1"),
     customId: "view_wallets",
     style: "SECONDARY",


### PR DESCRIPTION
**What does this PR do?**

-   [x] Add cmd `/wallet list` to view list tracking wallets
![image](https://github.com/consolelabs/mochi-discord/assets/32956772/1f24bb73-687f-4629-976d-2801c538415f)
-   [x] Fix API `/wallet view <address>` to view wallet detail
![image](https://github.com/consolelabs/mochi-discord/assets/32956772/1fa5ddf1-583d-4ed2-a013-41d5d180cbe1)
-   [x] Modify `machineConfig` of wallet cmd group to route between states, and re-map/add button `wallets` to a few messages such as wallet details. 
![image](https://github.com/consolelabs/mochi-discord/assets/32956772/cfcc1310-93a4-4531-be1f-6c49dbe04d6c)
-   [x] Map list wallet dropdown to see wallet detail when clicking on each item
![image](https://github.com/consolelabs/mochi-discord/assets/32956772/52b0b4a5-8a20-4239-ab1f-1e6bcb57717e)
