### PR TITLE
fix: default ticker empty view

### DIFF
--- a/src/commands/default/ticker/info/slash.ts
+++ b/src/commands/default/ticker/info/slash.ts
@@ -4,7 +4,13 @@ import { SlashCommand, embedsColors } from "types/common"
 import { GM_GITBOOK, SLASH_PREFIX } from "utils/constants"
 import { composeEmbedMessage, formatDataTable } from "ui/discord/embed"
 import get from "./processor"
-import { TokenEmojiKey, getEmojiToken, thumbnails } from "utils/common"
+import {
+  TokenEmojiKey,
+  getEmoji,
+  getEmojiToken,
+  thumbnails,
+} from "utils/common"
+import { getSlashCommand } from "utils/commands"
 
 const command: SlashCommand = {
   name: "info",
@@ -16,6 +22,30 @@ const command: SlashCommand = {
   },
   run: async function (interaction: CommandInteraction) {
     const cfgs = await get(interaction)
+
+    if (cfgs.length === 0) {
+      return {
+        messageOptions: {
+          embeds: [
+            composeEmbedMessage(null, {
+              color: embedsColors.Server,
+              description: `You haven't set any default ticker yet. \n\n${getEmoji(
+                "ANIMATED_POINTING_RIGHT",
+                true
+              )} To set a new one, run ${await getSlashCommand(
+                "default ticker set"
+              )}.\n${getEmoji(
+                "ANIMATED_POINTING_RIGHT",
+                true
+              )} To view all available default ticker, run ${await getSlashCommand(
+                "default ticker info"
+              )}.`,
+            }),
+          ],
+        },
+      }
+    }
+
     const output = formatDataTable(
       cfgs.map((cfg) => {
         return {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -81,8 +81,16 @@ export interface ModelAirdropCampaign {
   detail?: string;
   id?: number;
   prev_airdrop_campaign_id?: number;
+  reward_amount?: number;
+  reward_token_symbol?: string;
+  status?: string;
   title?: string;
   updated_at?: string;
+}
+
+export interface ModelAirdropStatusCount {
+  count?: number;
+  status?: string;
 }
 
 export interface ModelChain {
@@ -95,6 +103,7 @@ export interface ModelChain {
 
 export interface ModelCoingeckoSupportedTokens {
   current_price?: number;
+  detail_platforms?: number[];
   id?: string;
   most_popular?: boolean;
   name?: string;
@@ -474,19 +483,6 @@ export interface ModelJSONNullString {
   string?: string;
   /** Valid is true if String is not NULL */
   valid?: boolean;
-}
-
-export interface ModelKyberswapSupportedToken {
-  address?: string;
-  chain_id?: number;
-  chain_name?: string;
-  created_at?: string;
-  decimals?: number;
-  id?: number;
-  logo_uri?: string;
-  name?: string;
-  symbol?: string;
-  updated_at?: string;
 }
 
 export interface ModelMixRoleNFTRequirement {
@@ -997,7 +993,11 @@ export interface RequestConfigureInviteRequest {
 export interface RequestCreateAirdropCampaignRequest {
   deadline_at?: string;
   detail?: string;
+  id?: number;
   prev_airdrop_campaign_id?: number;
+  reward_amount?: number;
+  reward_token_symbol?: string;
+  status?: string;
   title?: string;
 }
 
@@ -1478,6 +1478,10 @@ export interface ResponseAddTokenPriceAlertResponse {
 
 export interface ResponseAirdropCampaignResponse {
   data?: ModelAirdropCampaign;
+}
+
+export interface ResponseAirdropCampaignStatResponse {
+  data?: ModelAirdropStatusCount[];
 }
 
 export interface ResponseAirdropCampaignsResponse {
@@ -2778,6 +2782,20 @@ export interface ResponseRouteSummary {
   tokenOutMarketPriceAvailable?: boolean;
 }
 
+export interface ResponseRouteToken {
+  address?: string;
+  chain_id?: number;
+  chain_name?: string;
+  coingecko_id?: string;
+  created_at?: string;
+  decimals?: number;
+  id?: number;
+  logo_uri?: string;
+  name?: string;
+  symbol?: string;
+  updated_at?: string;
+}
+
 export interface ResponseSearchCoinResponse {
   data?: ModelCoingeckoSupportedTokens[];
 }
@@ -2789,8 +2807,8 @@ export interface ResponseSparkLineIn7D {
 export interface ResponseSwapRoute {
   routeSummary?: ResponseRouteSummary;
   routerAddress?: string;
-  tokenIn?: ModelKyberswapSupportedToken;
-  tokenOut?: ModelKyberswapSupportedToken;
+  tokenIn?: ResponseRouteToken;
+  tokenOut?: ResponseRouteToken;
 }
 
 export interface ResponseSwapRouteResponse {


### PR DESCRIPTION
**What does this PR do?**

-   [x] handle empty case get guild's default ticker list

**How to test**

`/default ticker info`

**Media (Loom or gif)**

<img width="595" alt="CleanShot 2023-06-16 at 15 13 47@2x" src="https://github.com/consolelabs/mochi-discord/assets/14150687/1d1902b5-7e75-4e45-9d96-472b6644f110">

