### PR TITLE
fix: default ticker set autocomplete

### DIFF
--- a/src/commands/default/index.ts
+++ b/src/commands/default/index.ts
@@ -18,6 +18,12 @@ const subCommandGroups: Record<string, Record<string, SlashCommand>> = {
 const slashCmd: SlashCommand = {
   name: "default",
   category: "Config",
+  autocomplete: function (i) {
+    subCommandGroups[i.options.getSubcommandGroup(true)][
+      i.options.getSubcommand(true)
+    ].autocomplete?.(i)
+    return Promise.resolve()
+  },
   onlyAdministrator: function (i) {
     const onlyAdmin =
       subCommandGroups[i.options.getSubcommandGroup(true)][


### PR DESCRIPTION
**What does this PR do?**

-   [x] Fix autocomplete for default ticker set

**How to test**

`/default ticker set`

**Media (Loom or gif)**

<img width="581" alt="CleanShot 2023-06-21 at 17 26 40@2x" src="https://github.com/consolelabs/mochi-discord/assets/14150687/c4ea2935-8cb1-42c5-b962-eb9dda0579ec">
