### PR TITLE
chore: handle error execute swap

### DIFF
--- a/src/commands/swap/index/processor.ts
+++ b/src/commands/swap/index/processor.ts
@@ -555,7 +555,25 @@ export async function executeSwap(i: ButtonInteraction, ctx?: Context) {
     }
   }
 
-  await defi.swap(i.user.id, ctx.chainName, ctx.routeSummary)
+  const { ok, originalError } = await defi.swap(
+    i.user.id,
+    ctx.chainName,
+    ctx.routeSummary
+  )
+  if (!ok) {
+    return {
+      msgOpts: {
+        embeds: [
+          getErrorEmbed({
+            title: "Swap request failed",
+            description: originalError ?? "Internal error.",
+          }),
+        ],
+        components: [],
+      },
+    }
+  }
+
   const dm = await dmUser(
     {
       embeds: [


### PR DESCRIPTION
In executeSwap() balances can drop down because user tip / wd / transfer vault / ... before this
- Old: Go ahead and Dm user but the swap is never executed
<img width="466" alt="image" src="https://github.com/consolelabs/mochi-discord/assets/39881166/4bc2cf08-bb1e-4fc6-84d1-98c72605f751">

- New: catch error and no Dm user
<img width="412" alt="image" src="https://github.com/consolelabs/mochi-discord/assets/39881166/b8239443-5fee-4f8c-8cbf-430f9f7cb2b2">
