### PR TITLE
feat: add cmd wallet alias

### DIFF
--- a/src/adapters/defi.ts
+++ b/src/adapters/defi.ts
@@ -18,6 +18,7 @@ import {
   INDEXER_API_BASE_URL,
   POLYGONSCAN_API,
 } from "utils/constants"
+
 import { Fetcher } from "./fetcher"
 
 class Defi extends Fetcher {
@@ -355,6 +356,20 @@ class Defi extends Fetcher {
       `${API_BASE_URL}/users/${body.userId}/watchlists/wallets/track`,
       {
         method: "POST",
+        body,
+      }
+    )
+  }
+
+  async updateTrackingInfo(body: {
+    userId: string
+    wallet: string
+    alias: string
+  }) {
+    return await this.jsonFetch(
+      `${API_BASE_URL}/users/${body.userId}/watchlists/wallets/${body.wallet}`,
+      {
+        method: "PUT",
         body,
       }
     )

--- a/src/commands/wallet/alias/index.ts
+++ b/src/commands/wallet/alias/index.ts
@@ -1,0 +1,4 @@
+import remove from "./remove/slash"
+import set from "./set/slash"
+
+export default { set, remove }

--- a/src/commands/wallet/alias/remove/slash.ts
+++ b/src/commands/wallet/alias/remove/slash.ts
@@ -1,0 +1,33 @@
+import { CommandInteraction } from "discord.js"
+import { SlashCommand } from "types/common"
+
+import { SlashCommandSubcommandBuilder } from "@discordjs/builders"
+
+import { updateAlias } from "../set/processor"
+
+const command: SlashCommand = {
+  name: "remove",
+  category: "Defi",
+  prepare: () => {
+    return new SlashCommandSubcommandBuilder()
+      .setName("remove")
+      .setDescription("Remove wallet's alias")
+      .addStringOption((opt) =>
+        opt
+          .setName("wallet")
+          .setDescription("Current alias or wallet address")
+          .setRequired(true)
+      )
+  },
+  run: async function (i: CommandInteraction) {
+    const wallet = i.options.getString("wallet", true)
+
+    const { msgOpts } = await updateAlias(i, i.user, wallet)
+
+    await i.editReply(msgOpts)
+  },
+  help: () => Promise.resolve({}),
+  colorType: "Defi",
+}
+
+export default command

--- a/src/commands/wallet/alias/set/processor.ts
+++ b/src/commands/wallet/alias/set/processor.ts
@@ -1,0 +1,151 @@
+import defi from "adapters/defi"
+import { User } from "discord.js"
+import { InternalError, OriginalMessage } from "errors"
+import { composeEmbedMessage } from "ui/discord/embed"
+import { getSlashCommand } from "utils/commands"
+import {
+  AddressChainType,
+  EmojiKey,
+  emojis,
+  getEmoji,
+  getEmojiURL,
+  isAddress,
+  msgColors,
+  shortenHashOrAddress,
+} from "utils/common"
+
+export async function updateAlias(
+  msg: OriginalMessage,
+  author: User,
+  wallet: string,
+  alias = ""
+) {
+  const { data, status } = await defi.updateTrackingInfo({
+    userId: author.id,
+    wallet,
+    alias,
+  })
+
+  if (status !== 200) {
+    throw new InternalError(
+      await composeAliasErrorMsg(msg, wallet, alias, status)
+    )
+  }
+
+  const { chainType } = isAddress(data?.address || "")
+
+  if (alias === "") {
+    return await composeAliasRemovedMsg(data, chainType)
+  }
+
+  return await composeAliasUpdatedMsg(data, chainType, alias)
+}
+
+async function composeAliasUpdatedMsg(
+  data: Record<string, any> | null,
+  chainType: AddressChainType,
+  alias: string
+) {
+  return {
+    msgOpts: {
+      embeds: [
+        composeEmbedMessage(null, {
+          author: [`Alias is updated`, getEmojiURL(emojis.CHECK)],
+          color: msgColors.SUCCESS,
+          description: `
+${getEmoji(
+  "ANIMATED_POINTING_RIGHT",
+  true
+)} You can see used aliases by using ${await getSlashCommand("wallet list")}.
+${getEmoji("ANIMATED_POINTING_RIGHT", true)} Use ${await getSlashCommand(
+            "wallet alias set"
+          )} to change to another alias.\n
+**Detail**
+${getEmoji("WALLET_1")} \`Wallet.    ${shortenHashOrAddress(
+            data?.address
+          )}\` ${getEmoji(chainType as EmojiKey)}
+${getEmoji("CONVERSION")} \`Alias.     ${
+            alias.length >= 16 ? shortenHashOrAddress(alias) : alias
+          }\`
+          `,
+        }),
+      ],
+    },
+  }
+}
+
+async function composeAliasRemovedMsg(
+  data: Record<string, any> | null,
+  chainType: AddressChainType
+) {
+  return {
+    msgOpts: {
+      embeds: [
+        composeEmbedMessage(null, {
+          author: [`Alias is removed`, getEmojiURL(emojis.CHECK)],
+          color: msgColors.SUCCESS,
+          description: `
+${getEmoji(
+  "ANIMATED_POINTING_RIGHT",
+  true
+)} You can see used aliases by using ${await getSlashCommand("wallet list")}.
+${getEmoji("ANIMATED_POINTING_RIGHT", true)} Use ${await getSlashCommand(
+            "wallet alias set"
+          )} to change to another alias.\n
+**Detail**
+${getEmoji("WALLET_1")} \`Wallet.    ${shortenHashOrAddress(
+            data?.address
+          )}\` ${getEmoji(chainType as EmojiKey)}
+`,
+        }),
+      ],
+    },
+  }
+}
+
+async function composeAliasErrorMsg(
+  msg: OriginalMessage,
+  wallet: string,
+  alias: string,
+  code: number | undefined
+) {
+  let reason = ""
+  switch (code) {
+    case 409:
+      reason = "Alias already exists"
+      break
+    case 404:
+      reason = "Wallet not found"
+      break
+    default:
+      reason = "Unexpected internal error"
+      break
+  }
+
+  let description = `
+    ${getEmoji(
+      "ANIMATED_POINTING_RIGHT",
+      true
+    )} Some unexpected error occurred. Please try again later!
+    ${getEmoji(
+      "ANIMATED_POINTING_RIGHT",
+      true
+    )} Can try ${await getSlashCommand(
+    "wallet list"
+  )} to see your tracking wallets.
+
+    **Detail**
+    ${getEmoji("CONFIG")}\`Reason.   \`${reason}
+    ${getEmoji("WALLET_1")}\`Wallet.   \`${shortenHashOrAddress(wallet)}
+  `
+
+  if (alias !== "") {
+    description += `${getEmoji("CONVERSION")}\`Alias.    \`${alias}`
+  }
+
+  return {
+    msgOrInteraction: msg,
+    title: alias === "" ? "Remove alias failed" : "Set alias failed",
+    description: description,
+  }
+}

--- a/src/commands/wallet/alias/set/slash.ts
+++ b/src/commands/wallet/alias/set/slash.ts
@@ -1,0 +1,40 @@
+import { CommandInteraction } from "discord.js"
+import { SlashCommand } from "types/common"
+
+import { SlashCommandSubcommandBuilder } from "@discordjs/builders"
+
+import { updateAlias } from "./processor"
+
+const command: SlashCommand = {
+  name: "set",
+  category: "Defi",
+  prepare: () => {
+    return new SlashCommandSubcommandBuilder()
+      .setName("set")
+      .setDescription("Set alias for a crypto wallet")
+      .addStringOption((opt) =>
+        opt
+          .setName("wallet")
+          .setDescription("Current alias or wallet address")
+          .setRequired(true)
+      )
+      .addStringOption((opt) =>
+        opt
+          .setName("alias")
+          .setDescription("New alias for this wallet")
+          .setRequired(true)
+      )
+  },
+  run: async function (i: CommandInteraction) {
+    const wallet = i.options.getString("wallet", true)
+    const alias = i.options.getString("alias", true)
+
+    const { msgOpts } = await updateAlias(i, i.user, wallet, alias)
+
+    await i.editReply(msgOpts)
+  },
+  help: () => Promise.resolve({}),
+  colorType: "Defi",
+}
+
+export default command

--- a/src/commands/wallet/list/processor.ts
+++ b/src/commands/wallet/list/processor.ts
@@ -3,9 +3,13 @@ import { MessageActionRow, MessageSelectMenu, User } from "discord.js"
 import { ResponseGetTrackingWalletsResponse } from "types/api"
 import { composeEmbedMessage, formatDataTable } from "ui/discord/embed"
 import { getSlashCommand } from "utils/commands"
-import { emojis } from "utils/common"
-import { getEmojiURL } from "utils/common"
-import { getEmoji, shortenHashOrAddress, capitalizeFirst } from "utils/common"
+import {
+  capitalizeFirst,
+  emojis,
+  getEmoji,
+  getEmojiURL,
+  shortenHashOrAddress,
+} from "utils/common"
 import { APPROX, VERTICAL_BAR } from "utils/constants"
 import { formatDigit } from "utils/defi"
 
@@ -64,7 +68,11 @@ export async function render(user: User) {
             const chain = (d.chain_type ?? "").toUpperCase()
             return {
               chainType: chain,
-              address: d.alias || shortenHashOrAddress(d.address ?? "", 4),
+              address: shortenHashOrAddress(d.address ?? "", 4),
+              alias:
+                (d?.alias ?? "").length >= 16
+                  ? shortenHashOrAddress(d.alias ?? "", 4)
+                  : d.alias ?? "",
               usd: `$${formatDigit({
                 value: String(d.net_worth ?? 0),
                 fractionDigits: 2,
@@ -72,8 +80,8 @@ export async function render(user: User) {
             }
           }),
         {
-          cols: ["chainType", "address", "usd"],
-          separator: [VERTICAL_BAR, ` ${APPROX} `],
+          cols: ["chainType", "address", "alias", "usd"],
+          separator: [VERTICAL_BAR, VERTICAL_BAR, ` ${APPROX} `],
           rowAfterFormatter: (f, i) =>
             `${getEmoji(e[1][i].chain_type.toUpperCase())} ${f}${getEmoji(
               "CASH"

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1181,9 +1181,7 @@ export interface RequestGenerateVerificationRequest {
   user_discord_id?: string;
 }
 
-export interface RequestGetTrackingWalletsRequest {
-  userID: string;
-}
+export type RequestGetTrackingWalletsRequest = object;
 
 export interface RequestGuildConfigDefaultNftTickerRequest {
   chain_id?: number;
@@ -1336,6 +1334,11 @@ export interface RequestUpdateQuestProgressRequest {
   action?: string;
   guild_id?: string;
   user_id?: string;
+}
+
+export interface RequestUpdateTrackingInfoRequest {
+  /** Request body, only update the following fields */
+  alias?: string;
 }
 
 export interface RequestUpdateUserFeedbackRequest {

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,3 +1,6 @@
+import CacheManager from "cache/node-cache"
+import dayjs from "dayjs"
+import relativeTime from "dayjs/plugin/relativeTime"
 import {
   ColorResolvable,
   GuildMember,
@@ -6,17 +9,6 @@ import {
   Permissions,
   User,
 } from "discord.js"
-
-import {
-  NameRegistryState,
-  getHashedNameSync,
-  getNameAccountKeySync,
-  reverseLookup as performReverseLookup,
-} from "@bonfida/spl-name-service"
-import { Connection, PublicKey, clusterApiUrl } from "@solana/web3.js"
-import CacheManager from "cache/node-cache"
-import dayjs from "dayjs"
-import relativeTime from "dayjs/plugin/relativeTime"
 import { MARKETPLACE_BASE_URL } from "env"
 import { OriginalMessage } from "errors"
 import { ethers } from "ethers"
@@ -25,6 +17,15 @@ import fetch from "node-fetch"
 import type { Pagination } from "types/common"
 import { TopNFTTradingVolumeItem } from "types/community"
 import providers from "utils/providers"
+
+import {
+  getHashedNameSync,
+  getNameAccountKeySync,
+  NameRegistryState,
+  reverseLookup as performReverseLookup,
+} from "@bonfida/spl-name-service"
+import { clusterApiUrl, Connection, PublicKey } from "@solana/web3.js"
+
 import { DOT, SPACE } from "./constants"
 import {
   marketplaceEmojis,
@@ -32,6 +33,7 @@ import {
   traitEmojis,
   traitTypeMapping,
 } from "./nft"
+
 dayjs.extend(relativeTime)
 
 const SOL_TLD_AUTHORITY = new PublicKey(
@@ -449,6 +451,7 @@ export const emojis = {
   OCEAN: "1113115314113224764",
   NO: "1112604245875765319",
   METAMASK: "1121380474766491648",
+  CHAT: "1078633889247006790",
   ...animatedEmojis,
   ...tokenEmojis,
   ...numberEmojis,
@@ -822,7 +825,7 @@ export function isValidSuiAddress(value: string): boolean {
 
 export enum AddressChainType {
   EVM = "EVM",
-  SOL = "SOl",
+  SOL = "SOL",
   SUI = "SUI",
   RON = "RON",
   UNKNOWN = "",


### PR DESCRIPTION
**What does this PR do?**

-   [x] add cmd wallet alias

**How to test**
- `/wallet alias set <address/current alias> <new alias>` ->  add/update alias
![image](https://github.com/consolelabs/mochi-discord/assets/32956772/3500471a-0b57-403d-bc4f-7c13ad0e5e64)

- `/wallet alias remove <address/current alias>` -> remove alias
<img width="679" alt="image" src="https://github.com/consolelabs/mochi-discord/assets/32956772/bc9e3871-e580-4352-9195-d8ac6f224b3d">

- Error messages
![image](https://github.com/consolelabs/mochi-discord/assets/32956772/bb048eb1-541f-46c1-959a-da4e260913f3)

- Reformat wallet watchlist, show both address and alias
![image](https://github.com/consolelabs/mochi-discord/assets/32956772/242f59da-068b-4736-83b3-8a2ee0212b91)
