### PR TITLE
fix: wallet flow bugs

### DIFF
--- a/src/commands/wallet/common/tracking.ts
+++ b/src/commands/wallet/common/tracking.ts
@@ -1,11 +1,11 @@
+import { machineConfig as balanceMachineConfig } from "commands/balances/index/slash"
+import { render as renderTrackingWallets } from "commands/wallet/list/processor"
 import { MachineConfig } from "utils/router"
+
 import { copyWallet } from "../copy/processor"
 import { followWallet } from "../follow/processor"
-import { untrackWallet } from "../untrack/processor"
 import { trackWallet } from "../track/processor"
-import { render as renderTrackingWallets } from "commands/wallet/list/processor"
-import { machineConfig as balanceMachineConfig } from "commands/balances/index/slash"
-import { BalanceType } from "commands/balances/index/processor"
+import { untrackWallet } from "../untrack/processor"
 
 export const machineConfig: (id: string, context?: any) => MachineConfig = (
   id,
@@ -16,11 +16,11 @@ export const machineConfig: (id: string, context?: any) => MachineConfig = (
   context: {
     button: {
       walletFollow: (i, _ev, ctx) =>
-        followWallet(i, i.user, ctx.address, ctx.chain, ctx.alias),
+        followWallet(i, i.user, ctx.address, ctx.alias),
       walletTrack: (i, _ev, ctx) =>
-        trackWallet(i, i.user, ctx.address, ctx.chain, ctx.alias),
+        trackWallet(i, i.user, ctx.address, ctx.alias),
       walletCopy: (i, _ev, ctx) =>
-        copyWallet(i, i.user, ctx.address, ctx.chain, ctx.alias),
+        copyWallet(i, i.user, ctx.address, ctx.alias),
       walletUntrack: (i, _ev, ctx) => untrackWallet(i, i.user, ctx.address),
       wallets: (i) => renderTrackingWallets(i.user),
     },
@@ -66,7 +66,7 @@ export const machineConfig: (id: string, context?: any) => MachineConfig = (
         COPY_WALLET: "walletCopy",
         UNTRACK_WALLET: "walletUntrack",
       },
-      ...balanceMachineConfig({ type: BalanceType.Onchain }),
+      ...balanceMachineConfig({}),
     },
     wallets: {
       id: "wallets",

--- a/src/commands/wallet/copy/processor.ts
+++ b/src/commands/wallet/copy/processor.ts
@@ -18,7 +18,6 @@ export async function copyWallet(
   msg: OriginalMessage,
   author: User,
   address: string,
-  chain: string,
   alias = ""
 ) {
   const resolvedAddress = await resolveNamingServiceDomain(address)
@@ -57,7 +56,7 @@ export async function copyWallet(
       description: "Couldn't copy wallet",
     })
   }
-  const { msgOpts } = renderTrackingResult(address, chain, alias)
+  const { msgOpts } = renderTrackingResult(address, chainType, alias)
 
   return { msgOpts, context: { user: author, address } }
 }

--- a/src/commands/wallet/copy/slash.ts
+++ b/src/commands/wallet/copy/slash.ts
@@ -1,9 +1,11 @@
-import { SlashCommandSubcommandBuilder } from "@discordjs/builders"
+import { machineConfig } from "commands/wallet/common/tracking"
 import { CommandInteraction, Message } from "discord.js"
 import { SlashCommand } from "types/common"
-import { copyWallet } from "./processor"
 import { route } from "utils/router"
-import { machineConfig } from "commands/wallet/common/tracking"
+
+import { SlashCommandSubcommandBuilder } from "@discordjs/builders"
+
+import { copyWallet } from "./processor"
 
 const command: SlashCommand = {
   name: "copy",
@@ -20,12 +22,6 @@ const command: SlashCommand = {
       )
       .addStringOption((opt) =>
         opt
-          .setName("chain")
-          .setDescription("the chain of that address")
-          .setRequired(false)
-      )
-      .addStringOption((opt) =>
-        opt
           .setName("alias")
           .setDescription("something easier for you to remember")
           .setRequired(false)
@@ -33,16 +29,9 @@ const command: SlashCommand = {
   },
   run: async function (i: CommandInteraction) {
     const address = i.options.getString("address", true)
-    const chain = i.options.getString("chain", false) ?? "evm"
     const alias = i.options.getString("alias", false) ?? ""
 
-    const { msgOpts, context } = await copyWallet(
-      i,
-      i.user,
-      address,
-      chain,
-      alias
-    )
+    const { msgOpts, context } = await copyWallet(i, i.user, address, alias)
     const reply = await i.editReply(msgOpts)
 
     route(reply as Message, i, machineConfig("walletCopy", context))

--- a/src/commands/wallet/follow/processor.ts
+++ b/src/commands/wallet/follow/processor.ts
@@ -19,7 +19,6 @@ export async function followWallet(
   msg: OriginalMessage,
   author: User,
   address: string,
-  chain: string,
   alias = ""
 ) {
   const resolvedAddress = await resolveNamingServiceDomain(address)
@@ -59,7 +58,7 @@ export async function followWallet(
     })
   }
 
-  const { msgOpts } = await renderTrackingResult(address, chain, alias)
+  const { msgOpts } = await renderTrackingResult(address, chainType, alias)
 
   return { msgOpts, context: { user: author, address } }
 }

--- a/src/commands/wallet/follow/slash.ts
+++ b/src/commands/wallet/follow/slash.ts
@@ -1,9 +1,11 @@
-import { SlashCommandSubcommandBuilder } from "@discordjs/builders"
+import { machineConfig } from "commands/wallet/common/tracking"
 import { CommandInteraction, Message } from "discord.js"
 import { SlashCommand } from "types/common"
-import { followWallet } from "./processor"
 import { route } from "utils/router"
-import { machineConfig } from "commands/wallet/common/tracking"
+
+import { SlashCommandSubcommandBuilder } from "@discordjs/builders"
+
+import { followWallet } from "./processor"
 
 const command: SlashCommand = {
   name: "follow",
@@ -20,12 +22,6 @@ const command: SlashCommand = {
       )
       .addStringOption((opt) =>
         opt
-          .setName("chain")
-          .setDescription("the chain of that address")
-          .setRequired(false)
-      )
-      .addStringOption((opt) =>
-        opt
           .setName("alias")
           .setDescription("something easier for you to remember")
           .setRequired(false)
@@ -33,16 +29,9 @@ const command: SlashCommand = {
   },
   run: async function (i: CommandInteraction) {
     const address = i.options.getString("address", true)
-    const chain = i.options.getString("chain", false) ?? "evm"
     const alias = i.options.getString("alias", false) ?? ""
 
-    const { msgOpts, context } = await followWallet(
-      i,
-      i.user,
-      address,
-      chain,
-      alias
-    )
+    const { msgOpts, context } = await followWallet(i, i.user, address, alias)
     const reply = await i.editReply(msgOpts)
 
     route(reply as Message, i, machineConfig("walletFollow", context))

--- a/src/commands/wallet/list/processor.ts
+++ b/src/commands/wallet/list/processor.ts
@@ -99,7 +99,7 @@ export async function render(user: User) {
         .map((d) => {
           const chain = (d.chain_type ?? "").toUpperCase()
           return {
-            value: `${e[0]}_${d.user_id}_${d.address}`,
+            value: `${e[0]}_onchain_${d.address}`,
             label: `🔹 ${chain} | ${
               d.alias || shortenHashOrAddress(d.address ?? "", 4)
             } | 💵 $${formatDigit({

--- a/src/commands/wallet/track/processor.ts
+++ b/src/commands/wallet/track/processor.ts
@@ -18,7 +18,6 @@ export async function trackWallet(
   msg: OriginalMessage,
   author: User,
   address: string,
-  chain: string,
   alias = ""
 ) {
   const resolvedAddress = await resolveNamingServiceDomain(address)
@@ -58,7 +57,7 @@ export async function trackWallet(
     })
   }
 
-  const { msgOpts } = renderTrackingResult(address, chain, alias)
+  const { msgOpts } = renderTrackingResult(address, chainType, alias)
 
   return { msgOpts, context: { user: author, address } }
 }

--- a/src/commands/wallet/track/slash.ts
+++ b/src/commands/wallet/track/slash.ts
@@ -1,12 +1,14 @@
-import { SlashCommandSubcommandBuilder } from "@discordjs/builders"
+import { machineConfig } from "commands/wallet/common/tracking"
 import { CommandInteraction, Message } from "discord.js"
 import { SlashCommand } from "types/common"
-import { trackWallet } from "./processor"
 import { composeEmbedMessage2 } from "ui/discord/embed"
 import { thumbnails } from "utils/common"
 import { SLASH_PREFIX } from "utils/constants"
 import { route } from "utils/router"
-import { machineConfig } from "commands/wallet/common/tracking"
+
+import { SlashCommandSubcommandBuilder } from "@discordjs/builders"
+
+import { trackWallet } from "./processor"
 
 const command: SlashCommand = {
   name: "track",
@@ -23,12 +25,6 @@ const command: SlashCommand = {
       )
       .addStringOption((opt) =>
         opt
-          .setName("chain")
-          .setDescription("the chain of that address")
-          .setRequired(false)
-      )
-      .addStringOption((opt) =>
-        opt
           .setName("alias")
           .setDescription("something easier for you to remember")
           .setRequired(false)
@@ -36,16 +32,9 @@ const command: SlashCommand = {
   },
   run: async function (i: CommandInteraction) {
     const address = i.options.getString("address", true)
-    const chain = i.options.getString("chain", false) ?? "evm"
     const alias = i.options.getString("alias", false) ?? ""
 
-    const { msgOpts, context } = await trackWallet(
-      i,
-      i.user,
-      address,
-      chain,
-      alias
-    )
+    const { msgOpts, context } = await trackWallet(i, i.user, address, alias)
     const reply = await i.editReply(msgOpts)
 
     route(reply as Message, i, machineConfig("walletTrack", context))

--- a/src/commands/watchlist/view/slash.ts
+++ b/src/commands/watchlist/view/slash.ts
@@ -1,16 +1,20 @@
-import { SlashCommandSubcommandBuilder } from "@discordjs/builders"
+import { BalanceType } from "commands/balances/index/processor"
+import { machineConfig as balanceMachineConfig } from "commands/balances/index/slash"
+import { render as renderTrackingWallets } from "commands/wallet/list/processor"
 import { CommandInteraction, Message } from "discord.js"
 import { SlashCommand } from "types/common"
+import { composeEmbedMessage2 } from "ui/discord/embed"
+import { thumbnails } from "utils/common"
+import { SLASH_PREFIX } from "utils/constants"
+import { MachineConfig, route, RouterSpecialAction } from "utils/router"
+
+import { SlashCommandSubcommandBuilder } from "@discordjs/builders"
+
 import {
   composeWatchlist,
   WatchListTokenViewType,
   WatchListViewType,
 } from "./processor"
-import { composeEmbedMessage2 } from "ui/discord/embed"
-import { thumbnails } from "utils/common"
-import { SLASH_PREFIX } from "utils/constants"
-import { MachineConfig, route, RouterSpecialAction } from "utils/router"
-import { render as renderTrackingWallets } from "commands/wallet/list/processor"
 
 export const machineConfig: (ctx?: any) => MachineConfig = (context = {}) => ({
   id: "watchlist",
@@ -54,6 +58,7 @@ export const machineConfig: (ctx?: any) => MachineConfig = (context = {}) => ({
           on: {
             BACK: "wallets",
           },
+          ...balanceMachineConfig({ type: BalanceType.Onchain }),
         },
       },
     },

--- a/src/listeners/discord/interactionCreate.ts
+++ b/src/listeners/discord/interactionCreate.ts
@@ -1,17 +1,20 @@
+import config from "adapters/config"
 import CacheManager from "cache/node-cache"
+import { getRandomFact } from "cache/tip-fact-cache"
 import { slashCommands } from "commands"
 import { handleInteraction } from "commands/balances/index/processor"
+import { sendVerifyURL } from "commands/config/verify/processor"
 import { feedbackDispatcher } from "commands/feedback/index/processor"
 import { confirmGlobalXP } from "commands/globalxp/index/processor"
 import { handleNFTTickerViews } from "commands/nft/ticker/processor"
-import { handleDaoTrackerView } from "commands/proposal/info/processor"
-import {
-  handleProposalCancel,
-  handleProposalCreate,
-  handleProposalForm,
-  handleProposalVote,
-} from "commands/proposal/processor"
-import { subscribeCommonwealthDiscussion } from "commands/proposal/track/processor"
+// import { handleDaoTrackerView } from "commands/proposal/info/processor"
+// import {
+//   handleProposalCancel,
+//   handleProposalCreate,
+//   handleProposalForm,
+//   handleProposalVote,
+// } from "commands/proposal/processor"
+// import { subscribeCommonwealthDiscussion } from "commands/proposal/track/processor"
 import {
   handleBackToQuestList,
   handleClaimReward,
@@ -21,9 +24,8 @@ import {
   handleTokenReject,
 } from "commands/token/add/processor"
 import { handleTreasurerAdd } from "commands/vault/add/processor"
-import { handleTreasurerTransfer } from "commands/vault/transfer/processor"
 import { handleTreasurerRemove } from "commands/vault/remove/processor"
-import { sendVerifyURL } from "commands/config/verify/processor"
+import { handleTreasurerTransfer } from "commands/vault/transfer/processor"
 import {
   removeWallet,
   removeWalletConfirmation,
@@ -61,9 +63,9 @@ import {
 } from "utils/async-storages"
 import { authorFilter, getChance, hasAdministrator } from "utils/common"
 import { wrapError } from "utils/wrap-error"
-import { DiscordEvent } from "."
-import config from "adapters/config"
-import { getRandomFact } from "cache/tip-fact-cache"
+
+import { DiscordEvent } from "./"
+
 // import { handleBeginVerify } from "commands/config/verify/captcha/processor"
 
 const event: DiscordEvent<"interactionCreate"> = {
@@ -424,20 +426,20 @@ async function handleButtonInteraction(interaction: Interaction) {
     case i.customId.startsWith("feedback"):
       await feedbackDispatcher(i)
       return
-    case i.customId.startsWith("create-proposal"):
-      await handleProposalForm(i)
-      return
-    case i.customId.startsWith("proposal-confirm"):
-      await handleProposalCreate(i)
-      return
-    case i.customId.startsWith("proposal-cancel"):
-      await handleProposalCancel(i)
-      return
-    case i.customId.startsWith("proposal-vote"):
-      await handleProposalVote(i)
-      return
-    case i.customId.startsWith("proposal-info"):
-      await handleDaoTrackerView(i)
+      // case i.customId.startsWith("create-proposal"):
+      //   await handleProposalForm(i)
+      //   return
+      // case i.customId.startsWith("proposal-confirm"):
+      //   await handleProposalCreate(i)
+      //   return
+      // case i.customId.startsWith("proposal-cancel"):
+      //   await handleProposalCancel(i)
+      //   return
+      // case i.customId.startsWith("proposal-vote"):
+      //   await handleProposalVote(i)
+      //   return
+      // case i.customId.startsWith("proposal-info"):
+      //   await handleDaoTrackerView(i)
       return
     case i.customId.startsWith("wallet_remove_confirmation-"):
       await removeWalletConfirmation(i)
@@ -445,8 +447,8 @@ async function handleButtonInteraction(interaction: Interaction) {
     case i.customId.startsWith("wallet_remove-"):
       await removeWallet(i)
       return
-    case i.customId.startsWith("proposal_join_thread_commonwealth"):
-      await subscribeCommonwealthDiscussion(i)
+      // case i.customId.startsWith("proposal_join_thread_commonwealth"):
+      //   await subscribeCommonwealthDiscussion(i)
       return
     case i.customId.startsWith("token-request-approve"):
       await handleTokenApprove(i)


### PR DESCRIPTION
**What does this PR do?**

-   [x] Remove option `chain` from `/wallet follow/track/copy`
![image](https://github.com/consolelabs/mochi-discord/assets/32956772/8ab86be8-d705-494b-a940-04e8d9b4d862)
![image](https://github.com/consolelabs/mochi-discord/assets/32956772/c1c4848b-ff3f-4ffb-b8e1-1ebdac2090d7)
![image](https://github.com/consolelabs/mochi-discord/assets/32956772/de9a773d-2633-4b42-8fe8-a55858d50aa5)
- [x] Handle missing behavior of button in the balances UI
![image](https://github.com/consolelabs/mochi-discord/assets/32956772/1acc3674-9723-478b-81ac-f555f9b4521c)
- `/wlv -> wallets -> view wallet detail` does not work
![image](https://github.com/consolelabs/mochi-discord/assets/32956772/c848fccd-f949-4e12-b1f1-c9d215819e4f)
- `/profile-> pick wallet` shows wrong button, and these buttons is not updated as expected behavior: 
    - For example:
        - When I followed wallet X, then I view profile `/profile Meme -> pick wallet X` show `follow` button, but the expected button is `unfollow`
    - Reason: When routing to the view balance state, target user ID is another person (ex: Meme who has wallet X). And this person does not follow X.
    - Solution: 
        - When onchain wallet is picked  -> show balance by view of cmd’s author 
        - In other cases, show balance depend on target user


