### PR TITLE
feat: view member wallets

### DIFF
--- a/src/commands/wallet/index.ts
+++ b/src/commands/wallet/index.ts
@@ -15,7 +15,7 @@ import follow from "./follow/slash"
 import list from "./list/slash"
 import track from "./track/slash"
 import untrack from "./untrack/slash"
-import view from "./view/slash"
+import view from "./view"
 
 export enum WalletTrackingType {
   Follow = "follow",
@@ -24,7 +24,6 @@ export enum WalletTrackingType {
 }
 
 const slashActions: Record<string, SlashCommand> = {
-  view,
   add,
   track,
   follow,
@@ -35,6 +34,7 @@ const slashActions: Record<string, SlashCommand> = {
 
 const subCommandGroups: Record<string, Record<string, SlashCommand>> = {
   alias,
+  view,
 }
 
 const slashCmd: SlashCommand = {
@@ -44,7 +44,6 @@ const slashCmd: SlashCommand = {
     const data = new SlashCommandBuilder()
       .setName("wallet")
       .setDescription("Track assets and activities of any on-chain wallet.")
-    data.addSubcommand(<SlashCommandSubcommandBuilder>view.prepare())
     data.addSubcommand(<SlashCommandSubcommandBuilder>add.prepare())
     data.addSubcommand(<SlashCommandSubcommandBuilder>track.prepare())
     data.addSubcommand(<SlashCommandSubcommandBuilder>follow.prepare())
@@ -57,6 +56,13 @@ const slashCmd: SlashCommand = {
         .setDescription("Setup alias for wallet address")
         .addSubcommand(<SlashCommandSubcommandBuilder>alias.set.prepare())
         .addSubcommand(<SlashCommandSubcommandBuilder>alias.remove.prepare())
+    )
+    data.addSubcommandGroup((subcommandGroup) =>
+      subcommandGroup
+        .setName("view")
+        .setDescription("View wallet")
+        .addSubcommand(<SlashCommandSubcommandBuilder>view.address.prepare())
+        .addSubcommand(<SlashCommandSubcommandBuilder>view.profile.prepare())
     )
     return data
   },

--- a/src/commands/wallet/view/address/slash.ts
+++ b/src/commands/wallet/view/address/slash.ts
@@ -1,0 +1,95 @@
+import { SlashCommandSubcommandBuilder } from "@discordjs/builders"
+import profile from "adapters/profile"
+import {
+  BalanceType,
+  BalanceView,
+  renderBalances,
+} from "commands/balances/index/processor"
+import { CommandInteraction, Message } from "discord.js"
+import { SlashCommand } from "types/common"
+import { composeEmbedMessage2 } from "ui/discord/embed"
+import { SLASH_PREFIX, WALLET_GITBOOK } from "utils/constants"
+import { route } from "utils/router"
+import { machineConfig } from "commands/wallet/common/tracking"
+import { lookUpDomains } from "utils/common"
+import { formatUsdDigit } from "utils/defi"
+
+const command: SlashCommand = {
+  name: "view-address",
+  category: "Defi",
+  prepare: () => {
+    return new SlashCommandSubcommandBuilder()
+      .setName("address")
+      .setDescription("Show the wallet's assets and activities.")
+      .addStringOption((option) =>
+        option
+          .setName("wallet")
+          .setDescription(
+            "The address or alias of the wallet you want to track"
+          )
+          .setAutocomplete(true)
+          .setRequired(true)
+      )
+  },
+  autocomplete: async (i) => {
+    const focusedValue = i.options.getFocused()
+    // do not fetch amount because
+    // we need to respond within 3 seconds (discord api is amazing ¯\_(ツ)_/¯)
+    const { wallets } = await profile.getUserWallets(i.user.id, false)
+
+    const options = await Promise.all(
+      [...wallets]
+        .filter((w) =>
+          w.value.toLowerCase().startsWith(focusedValue.toLowerCase())
+        )
+        .map(async (w) => {
+          let value = w.value
+          if (value.startsWith("ronin:")) {
+            value = value.slice(6)
+          } else if (value.endsWith(".near")) {
+            value = value.slice(0, -5)
+          }
+
+          return {
+            value: w.value,
+            name: `🔷 ${w.chain.toUpperCase()} | ${
+              w.alias || (await lookUpDomains(w.value))
+            } | $${formatUsdDigit(w.total)}`,
+          }
+        })
+    )
+
+    await i.respond(options).catch(() => null)
+  },
+  run: async (interaction) => {
+    const address = interaction.options.getString("wallet", true)
+
+    const { context, msgOpts } = await renderBalances(
+      // TODO: this id currently is wrong
+      interaction.user.id,
+      {
+        interaction,
+        type: BalanceType.Onchain,
+        address,
+        view: BalanceView.Compact,
+      }
+    )
+
+    const reply = await interaction.editReply(msgOpts)
+
+    route(reply as Message, interaction, machineConfig("wallet", context))
+  },
+  help: (interaction: CommandInteraction) =>
+    Promise.resolve({
+      embeds: [
+        composeEmbedMessage2(interaction, {
+          usage: `${SLASH_PREFIX}wallet view [address]/[alias]`,
+          examples: `${SLASH_PREFIX}wallet view\n${SLASH_PREFIX}wallet view 0xfBe6403a719d0572Ea4BA0E1c01178835b1D3bE4\n${SLASH_PREFIX}wallet view mywallet`,
+          document: `${WALLET_GITBOOK}&action=view`,
+        }),
+      ],
+    }),
+  colorType: "Server",
+}
+
+export default command

--- a/src/commands/wallet/view/index.ts
+++ b/src/commands/wallet/view/index.ts
@@ -1,0 +1,4 @@
+import address from "./address/slash"
+import profile from "./profile/slash"
+
+export default { address, profile }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -48,6 +48,7 @@ export interface ModelCoingeckoSupportedTokens {
   detail_platforms?: number[];
   id?: string;
   is_native?: boolean;
+  is_not_supported?: boolean;
   is_popular?: boolean;
   most_popular?: boolean;
   name?: string;
@@ -1111,6 +1112,10 @@ export interface ResponseGetHistoricalMarketChartResponse {
   data?: ResponseCoinPriceHistoryResponse;
 }
 
+export interface ResponseGetInvestListResponse {
+  data?: ResponseInvestItem[];
+}
+
 export interface ResponseGetLevelRoleConfigsResponse {
   data?: ModelGuildConfigLevelRole[];
   /** page index */
@@ -1434,6 +1439,43 @@ export interface ResponseIndexerToken {
   address?: string;
   decimals?: number;
   is_native?: boolean;
+  symbol?: string;
+}
+
+export interface ResponseInvestChain {
+  id?: number;
+  logo?: string;
+  name?: string;
+}
+
+export interface ResponseInvestItem {
+  apy?: number;
+  chain?: ResponseInvestChain;
+  platforms?: ResponseInvestPlatforms[];
+  token?: ResponseInvestToken;
+  tvl?: number;
+}
+
+export interface ResponseInvestPlatforms {
+  apy?: number;
+  desc?: string;
+  logo?: string;
+  name?: string;
+  reward_apy?: number;
+  status?: ResponseInvestStatus;
+  tvl?: number;
+  type?: string;
+}
+
+export interface ResponseInvestStatus {
+  detail?: string;
+  value?: string;
+}
+
+export interface ResponseInvestToken {
+  address?: string;
+  decimals?: number;
+  name?: string;
   symbol?: string;
 }
 


### PR DESCRIPTION
**What does this PR do?**
-   [x] Update current cmd syntax: `/wallet view` -> `/wallet view address`
- [x] New cmd: View guild members' wallets -> `/wallet view profile <user> <wallet>`.

**Media**
1. `/wallet view profile`:  View other members' wallets
![image](https://github.com/consolelabs/mochi-discord/assets/34529672/8e70538b-0e28-48f6-8c89-841e73998f0a)

2. `/wallet view address`: view my wallets
![image](https://github.com/consolelabs/mochi-discord/assets/34529672/6b8c1d48-93f0-48e4-8a99-44e714531fbb)



