### PR TITLE
chore: add server name for list vault

### DIFF
--- a/src/commands/profile/index/processor.ts
+++ b/src/commands/profile/index/processor.ts
@@ -210,7 +210,7 @@ async function compose(
       ? [
           {
             name: "Vaults",
-            value: formatVaults(vaults),
+            value: formatVaults(vaults, i.guildId ?? ""),
             inline: false,
           },
         ]

--- a/src/commands/vault/list/processor.ts
+++ b/src/commands/vault/list/processor.ts
@@ -21,13 +21,18 @@ import { runGetVaultDetail } from "../info/processor"
 import { composeEmbedMessage, formatDataTable } from "ui/discord/embed"
 import { ModelVault } from "types/api"
 
-export function formatVaults(vaults: Array<ModelVault & { total?: string }>) {
+export function formatVaults(
+  vaults: Array<ModelVault & { total?: string }>,
+  guildId: string
+) {
   return formatDataTable(
     vaults.map((v) => ({
       name: `${v.name?.slice(0, 10) ?? ""}${
         (v.name ?? "").length > 10 ? "..." : ""
       }`,
-      address: shortenHashOrAddress(v.wallet_address ?? "", 3),
+      address:
+        (!guildId && v.discord_guild?.name) ||
+        shortenHashOrAddress(v.wallet_address ?? "", 3),
       threshold: `${v.threshold ?? 0}%`,
       balance: v.total?.toString() ? `$${v.total.toString()}` : "",
     })),
@@ -65,7 +70,7 @@ export async function runVaultList(interaction: CommandInteraction) {
     true
   )} View detail of the vault ${await getSlashCommand("vault info")}\n\n`
 
-  description += formatVaults(data)
+  description += formatVaults(data, interaction.guildId)
 
   const embed = composeEmbedMessage(null, {
     title: `${getEmoji("MOCHI_CIRCLE")} Vault List`,


### PR DESCRIPTION
**What does this PR do?**

-   [x] add server name for list vault
- use /profile in dm
<img width="610" alt="Screen Shot 2023-07-17 at 9 26 12 PM" src="https://github.com/consolelabs/mochi-discord/assets/39359294/73cb2594-b1e7-4ba3-a418-9bb2473b2335">

- use /profile in guild
<img width="582" alt="Screen Shot 2023-07-17 at 9 27 03 PM" src="https://github.com/consolelabs/mochi-discord/assets/39359294/12f061d9-e42c-412e-aee8-7b237bd851c3">
