### PR TITLE
fix: bug missing context alias when click tracking buttons

### DIFF
--- a/src/commands/balances/index/processor.ts
+++ b/src/commands/balances/index/processor.ts
@@ -1,4 +1,5 @@
 import defi from "adapters/defi"
+import mochiPay from "adapters/mochi-pay"
 import profile from "adapters/profile"
 import { renderWallets } from "commands/profile/index/processor"
 import { buildRecentTxFields } from "commands/vault/info/processor"
@@ -13,6 +14,8 @@ import {
   User,
 } from "discord.js"
 import { APIError, InternalError, OriginalMessage } from "errors"
+import { BigNumber } from "ethers"
+import { chunk, groupBy } from "lodash"
 import {
   composeEmbedMessage,
   formatDataTable,
@@ -37,12 +40,11 @@ import {
 import {
   APPROX,
   MIN_DUST,
-  TRACKING_TYPE_FOLLOW,
   TRACKING_TYPE_COPY,
+  TRACKING_TYPE_FOLLOW,
   TRACKING_TYPE_TRACK,
   VERTICAL_BAR,
 } from "utils/constants"
-import mochiPay from "adapters/mochi-pay"
 import { convertString } from "utils/convert"
 import {
   formatDigit,
@@ -51,8 +53,6 @@ import {
   formatUsdDigit,
 } from "utils/defi"
 import { getProfileIdByDiscord } from "utils/profile"
-import { BigNumber } from "ethers"
-import { chunk, groupBy } from "lodash"
 import { paginationButtons } from "utils/router"
 
 export enum BalanceType {
@@ -1048,6 +1048,7 @@ export async function renderBalances(
   return {
     context: {
       address,
+      alias: props?.alias,
       type,
       chain: addressType,
       showFullEarn,

--- a/src/commands/wallet/copy/processor.ts
+++ b/src/commands/wallet/copy/processor.ts
@@ -2,6 +2,7 @@ import defi from "adapters/defi"
 import { MessageActionRow, MessageButton, User } from "discord.js"
 import { InternalError, OriginalMessage } from "errors"
 import { composeEmbedMessage } from "ui/discord/embed"
+import { getSlashCommand } from "utils/commands"
 import {
   emojis,
   getEmoji,
@@ -58,16 +59,18 @@ export async function copyWallet(
       description: "Couldn't copy wallet",
     })
   }
-  const { msgOpts } = renderTrackingResult(address, chainType, alias)
-
-  return { msgOpts, context: { user: author, address } }
+  return await renderTrackingResult(author, address, alias)
 }
 
-function renderTrackingResult(address: string, chain: string, alias: string) {
+async function renderTrackingResult(
+  user: User,
+  address: string,
+  alias: string
+) {
   return {
     context: {
+      user,
       address,
-      chain,
       alias,
     },
     msgOpts: {
@@ -81,22 +84,17 @@ function renderTrackingResult(address: string, chain: string, alias: string) {
           ],
           color: msgColors.SUCCESS,
           description: `
+${getEmoji("ANIMATED_POINTING_RIGHT", true)} Use ${await getSlashCommand(
+            "wallet alias set"
+          )} to assign name for any tracking wallet.
 ${getEmoji(
   "ANIMATED_POINTING_RIGHT",
   true
-)} View wallet watchlist by clicking on button \`Watchlist\`.
+)} View list tracking wallet by clicking on button \`Wallets\` below.
 ${getEmoji(
   "ANIMATED_POINTING_RIGHT",
   true
-)} Follow this wallet by clicking on button \`Follow\`.
-${getEmoji(
-  "ANIMATED_POINTING_RIGHT",
-  true
-)} Track wallet's transactions by clicking on button \`Track\`.
-${getEmoji(
-  "ANIMATED_POINTING_RIGHT",
-  true
-)} To remove copy trade setting, click on button \`Uncopy\`.
+)} Pick any other buttons if you change your decision.
             `,
         }),
       ],

--- a/src/commands/wallet/follow/processor.ts
+++ b/src/commands/wallet/follow/processor.ts
@@ -60,20 +60,18 @@ export async function followWallet(
     })
   }
 
-  const { msgOpts } = await renderTrackingResult(address, chainType, alias)
-
-  return { msgOpts, context: { user: author, address } }
+  return await renderTrackingResult(author, address, alias)
 }
 
 async function renderTrackingResult(
+  user: User,
   address: string,
-  chain: string,
   alias: string
 ) {
   return {
     context: {
+      user,
       address,
-      chain,
       alias,
     },
     msgOpts: {
@@ -85,20 +83,17 @@ async function renderTrackingResult(
           ],
           color: msgColors.SUCCESS,
           description: `
-${getEmoji("ANIMATED_POINTING_RIGHT", true)} ${await getSlashCommand(
-            "wallet list"
-          )} tracking wallets.
-${getEmoji("ANIMATED_POINTING_RIGHT", true)} ${await getSlashCommand(
+${getEmoji("ANIMATED_POINTING_RIGHT", true)} Use ${await getSlashCommand(
             "wallet alias set"
-          )} note to your tracking wallets.
+          )} to assign name for any tracking wallet.
 ${getEmoji(
   "ANIMATED_POINTING_RIGHT",
   true
-)} Track this wallet's transaction by clicking on button \`Track\`.
+)} View list tracking wallet by clicking on button \`Wallets\` below.
 ${getEmoji(
   "ANIMATED_POINTING_RIGHT",
   true
-)} Copy trade by clicking on button \`Copy\`.
+)} Pick any other buttons if you change your decision.
             `,
         }),
       ],

--- a/src/commands/wallet/track/processor.ts
+++ b/src/commands/wallet/track/processor.ts
@@ -2,6 +2,7 @@ import defi from "adapters/defi"
 import { MessageActionRow, MessageButton, User } from "discord.js"
 import { InternalError, OriginalMessage } from "errors"
 import { composeEmbedMessage } from "ui/discord/embed"
+import { getSlashCommand } from "utils/commands"
 import {
   emojis,
   getEmoji,
@@ -59,16 +60,18 @@ export async function trackWallet(
     })
   }
 
-  const { msgOpts } = renderTrackingResult(address, chainType, alias)
-
-  return { msgOpts, context: { user: author, address } }
+  return await renderTrackingResult(author, address, alias)
 }
 
-function renderTrackingResult(address: string, chain: string, alias: string) {
+async function renderTrackingResult(
+  user: User,
+  address: string,
+  alias: string
+) {
   return {
     context: {
+      user,
       address,
-      chain,
       alias,
     },
     msgOpts: {
@@ -82,22 +85,17 @@ function renderTrackingResult(address: string, chain: string, alias: string) {
           ],
           color: msgColors.SUCCESS,
           description: `
+${getEmoji("ANIMATED_POINTING_RIGHT", true)} Use ${await getSlashCommand(
+            "wallet alias set"
+          )} to assign name for any tracking wallet.
 ${getEmoji(
   "ANIMATED_POINTING_RIGHT",
   true
-)} View wallet watchlist by clicking on button \`Watchlist\`.
+)} View list tracking wallet by clicking on button \`Wallets\` below.
 ${getEmoji(
   "ANIMATED_POINTING_RIGHT",
   true
-)} Follow this wallet by clicking on button \`Follow\`.
-${getEmoji(
-  "ANIMATED_POINTING_RIGHT",
-  true
-)} Copy trade by clicking on button \`Copy\`.
-${getEmoji(
-  "ANIMATED_POINTING_RIGHT",
-  true
-)} To untrack, click on button \`Untrack\`.
+)} Pick any other buttons if you change your decision.
             `,
         }),
       ],

--- a/src/commands/wallet/view/address/slash.ts
+++ b/src/commands/wallet/view/address/slash.ts
@@ -1,18 +1,19 @@
-import { SlashCommandSubcommandBuilder } from "@discordjs/builders"
 import profile from "adapters/profile"
 import {
   BalanceType,
   BalanceView,
   renderBalances,
 } from "commands/balances/index/processor"
+import { machineConfig } from "commands/wallet/common/tracking"
 import { CommandInteraction, Message } from "discord.js"
 import { SlashCommand } from "types/common"
 import { composeEmbedMessage2 } from "ui/discord/embed"
-import { SLASH_PREFIX, WALLET_GITBOOK } from "utils/constants"
-import { route } from "utils/router"
-import { machineConfig } from "commands/wallet/common/tracking"
 import { lookUpDomains } from "utils/common"
+import { SLASH_PREFIX, WALLET_GITBOOK } from "utils/constants"
 import { formatUsdDigit } from "utils/defi"
+import { route } from "utils/router"
+
+import { SlashCommandSubcommandBuilder } from "@discordjs/builders"
 
 const command: SlashCommand = {
   name: "view-address",

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,3 +1,4 @@
+import { swr } from "adapters/fetcher"
 import CacheManager from "cache/node-cache"
 import dayjs from "dayjs"
 import relativeTime from "dayjs/plugin/relativeTime"
@@ -33,7 +34,6 @@ import {
   traitEmojis,
   traitTypeMapping,
 } from "./nft"
-import { swr } from "adapters/fetcher"
 
 dayjs.extend(relativeTime)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1271,6 +1271,52 @@
   resolved "https://registry.yarnpkg.com/@sapphire/snowflake/-/snowflake-3.5.1.tgz#254521c188b49e8b2d4cc048b475fb2b38737fec"
   integrity sha512-BxcYGzgEsdlG0dKAyOm0ehLGm2CafIrfQTZGWgkfKYbj+pNNsorZ7EotuZukc2MT70E0UbppVbtpBrqpzVzjNA==
 
+"@sentry-internal/tracing@7.58.1":
+  version "7.58.1"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/tracing/-/tracing-7.58.1.tgz#9be915092793da7f1e63eb0c56c7663c6e639933"
+  integrity sha512-kOWKqyjYdDgvO6CacXneE9UrFQHT3BXF1UpCAlnHchW/TqRFmg89sJAEUjEPGzN7y6IaX1G4j2dBPDE0OFQi3w==
+  dependencies:
+    "@sentry/core" "7.58.1"
+    "@sentry/types" "7.58.1"
+    "@sentry/utils" "7.58.1"
+    tslib "^2.4.1 || ^1.9.3"
+
+"@sentry/core@7.58.1":
+  version "7.58.1"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.58.1.tgz#d4010f2b0bcfe87b57fa490c0c7ab7a567ed4707"
+  integrity sha512-hpeB5fZ5T6Jg1CBqz486jHgWuJ5R/HD0wyYX+S3LDDsHCJo6V3TxNuoxYDlTTerRRfZdTwr9GYJXskehpU26IA==
+  dependencies:
+    "@sentry/types" "7.58.1"
+    "@sentry/utils" "7.58.1"
+    tslib "^2.4.1 || ^1.9.3"
+
+"@sentry/node@^7.58.1":
+  version "7.58.1"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.58.1.tgz#fc48b8f6ddfa0402cfdec3706cf162df60052b32"
+  integrity sha512-XsSu0xg5SYcltMbatnRBcIZw9pXwGJoGbYDLuPhhuqBz2mnQ0mQ9Try9dn/agDU7KZzT0IyA1qkPXk0NkMe3rw==
+  dependencies:
+    "@sentry-internal/tracing" "7.58.1"
+    "@sentry/core" "7.58.1"
+    "@sentry/types" "7.58.1"
+    "@sentry/utils" "7.58.1"
+    cookie "^0.4.1"
+    https-proxy-agent "^5.0.0"
+    lru_map "^0.3.3"
+    tslib "^2.4.1 || ^1.9.3"
+
+"@sentry/types@7.58.1":
+  version "7.58.1"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.58.1.tgz#c67f99f9af82ea930cdf895d71ae049575e38bf7"
+  integrity sha512-OnKG+yrilPBeVNQK3biF0u/4IDjwH+boJU1XzJOnYdMRO8uzTWxvaRqpt0C8sVE9VAetRi2eutkzOgCXZISRrw==
+
+"@sentry/utils@7.58.1":
+  version "7.58.1"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.58.1.tgz#b5e8ee53ce2f8ba7833a4a4e28044eaa1da9fa2f"
+  integrity sha512-iC9xZJBHp4+MDrZjKwcmMUhI5sTmpUcttwmsJL9HA6ACW+L1XX2eGSDky5pSlhhVFR7q7jJnQ7YUlMQ/jcd8eQ==
+  dependencies:
+    "@sentry/types" "7.58.1"
+    tslib "^2.4.1 || ^1.9.3"
+
 "@sindresorhus/is@^4.3.0":
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.6.0.tgz#3c7c9c46e678feefe7a2e5bb609d3dbd665ffb3f"
@@ -2450,6 +2496,11 @@ convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.9.0.tgz#7faae62353fb4213366d0ca98358d22e8368b05f"
   integrity sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==
+
+cookie@^0.4.1:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
+  integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
 
 cosmiconfig@7.0.1:
   version "7.0.1"
@@ -4368,6 +4419,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+lru_map@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/lru_map/-/lru_map-0.3.3.tgz#b5c8351b9464cbd750335a79650a0ec0e56118dd"
+  integrity sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==
+
 make-dir@3.1.0, make-dir@^3.0.0, make-dir@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
@@ -5966,7 +6022,7 @@ tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.1, tslib@^2.4.0:
+tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.1, tslib@^2.4.0, "tslib@^2.4.1 || ^1.9.3":
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.0.tgz#b295854684dbda164e181d259a22cd779dcd7bc3"
   integrity sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==


### PR DESCRIPTION
**What does this PR do?**

-   [x] Missing context alias let tracking buttons ignore this field when update the tracking status
Example:  Using wallet track with alias -> click on button follow -> click on button wallets -> The alias is still remained in the tracking list
![image](https://github.com/consolelabs/mochi-discord/assets/32956772/3f7b607c-71ce-4486-908a-7796259b34af)

-   [x] Cmd `wallet list` does not show name service domain
![image](https://github.com/consolelabs/mochi-discord/assets/32956772/fc3ab6d5-4bcb-4ce4-bb2b-0ef38ca86cc5)
