### PR TITLE
fix: move invest portfolio to profile section

### DIFF
--- a/src/commands/invest/portfolio/processor.ts
+++ b/src/commands/invest/portfolio/processor.ts
@@ -1,0 +1,36 @@
+import { InvestBalance } from "types/mochipay"
+import { formatDataTable } from "ui/discord/embed"
+import { TokenEmojiKey, getEmoji } from "utils/common"
+import { APPROX, VERTICAL_BAR } from "utils/constants"
+import { formatTokenDigit, formatUsdDigit } from "utils/defi"
+
+export function composeInvestPortfolio(data: InvestBalance[]) {
+  const info = data.map((invest) => {
+    const decimals = invest.to_underlying_token.decimals
+    const tokenAmount =
+      Number(invest.to_underlying_token?.balance) / 10 ** decimals
+    const amount = `${formatTokenDigit(tokenAmount)} ${
+      invest.to_underlying_token.symbol
+    }`
+    const apy = `${formatTokenDigit(invest.apy)}%`
+    const usdWorth = `$${formatUsdDigit(invest.underlying_usd)}`
+    const platform = invest.platform.name || ""
+    const symbol = invest.to_underlying_token?.symbol || ""
+
+    return {
+      emoji: getEmoji(symbol as TokenEmojiKey),
+      amount,
+      usdWorth,
+      platform: platform,
+      apy: apy,
+    }
+  })
+
+  const { segments } = formatDataTable(info, {
+    cols: ["amount", "usdWorth", "platform", "apy"],
+    rowAfterFormatter: (f, i) => `${info[i].emoji}${f}${getEmoji("GIFT")}`,
+    separator: [` ${APPROX} `, VERTICAL_BAR, VERTICAL_BAR],
+  })
+
+  return `${segments.map((c) => c.join("\n"))}`
+}

--- a/src/commands/profile/index/slash.ts
+++ b/src/commands/profile/index/slash.ts
@@ -18,7 +18,6 @@ import { machineConfig as watchListMachineConfig } from "commands/watchlist/view
 import { machineConfig as qrCodeMachineConfig } from "commands/qr/index/slash"
 import { machineConfig as earnMachineConfig } from "commands/earn/index"
 import { machineConfig as balanceMachineConfig } from "commands/balances/index/slash"
-import { machineConfig as investPortfolioMachineConfig } from "commands/invest/portfolio/slash"
 import { handleWalletAddition } from "commands/wallet/add/processor"
 import { runGetVaultDetail } from "commands/vault/info/processor"
 import { composeEmbedMessage } from "ui/discord/embed"
@@ -63,7 +62,6 @@ const machineConfig: (target: Target) => MachineConfig = (target) => ({
         VIEW_QUESTS: "earn",
         VIEW_ADD_WALLET: "addWallet",
         VIEW_QR_CODES: "qrCodes",
-        VIEW_INVEST_PORTFOLIO: "investPortfolio",
         CONNECT_BINANCE: {
           target: "profile",
           actions: {
@@ -117,12 +115,6 @@ const machineConfig: (target: Target) => MachineConfig = (target) => ({
         BACK: "profile",
       },
       ...earnMachineConfig,
-    },
-    investPortfolio: {
-      on: {
-        BACK: "profile",
-      },
-      ...investPortfolioMachineConfig(),
     },
   },
 })


### PR DESCRIPTION
**What does this PR do?**

-   [x] Move invest port into a section of profile 

**How to test**

- use command `/profile`

**Media (Loom or gif)**

<img width="668" alt="CleanShot 2023-07-28 at 09 27 18@2x" src="https://github.com/consolelabs/mochi-discord/assets/14150687/96bb4751-0b78-400c-9284-cd63fca18fbf">
