### PR TITLE
chore: udpate ticker dm and swap description

### DIFF
--- a/src/commands/swap/index.ts
+++ b/src/commands/swap/index.ts
@@ -120,13 +120,13 @@ const slashCmd: SlashCommand = {
       .addStringOption((option) =>
         option
           .setName("to")
-          .setDescription("the token you want to sell")
+          .setDescription("the token you want to buy")
           .setRequired(true)
       )
       .addStringOption((option) =>
         option
           .setName("from")
-          .setDescription("the token you want to buy")
+          .setDescription("the token you want to sell")
           .setRequired(false)
       )
       .addNumberOption((option) =>

--- a/src/commands/ticker/index.ts
+++ b/src/commands/ticker/index.ts
@@ -49,7 +49,7 @@ const slashCmd: SlashCommand = {
   run: async function (interaction: CommandInteraction) {
     const showAll = interaction.options.getBoolean("show-all") || false
     const baseQ = interaction.options.getString("base", true)
-    if (!interaction.guildId || !baseQ) return null
+    if (!baseQ) return null
     const targetQ = interaction.options.getString("target")
     const query = `${baseQ}${targetQ ? `/${targetQ}` : ""}`
     const { base, target, isCompare, isFiat } = parseTickerQuery(query)


### PR DESCRIPTION
**What does this PR do?**

-   [x]  update description for swap `to` and `from`

before:
<img width="280" alt="Screen Shot 2023-07-31 at 11 55 46 AM" src="https://github.com/consolelabs/mochi-discord/assets/39359294/69226040-9fee-4a25-be35-3f1dc53744f0">
<img width="259" alt="Screen Shot 2023-07-31 at 11 56 01 AM" src="https://github.com/consolelabs/mochi-discord/assets/39359294/292d9236-8dfc-4e68-8417-52347a971287">
after: 
<img width="240" alt="Screen Shot 2023-07-31 at 11 56 22 AM" src="https://github.com/consolelabs/mochi-discord/assets/39359294/79232eaf-b354-4693-b5ec-b147a1043481">
<img width="316" alt="Screen Shot 2023-07-31 at 11 56 32 AM" src="https://github.com/consolelabs/mochi-discord/assets/39359294/433d5a52-9190-492b-b13a-aea5e965cd7f">
-   [x]  update  ticker command for dm
<img width="566" alt="Screen Shot 2023-07-31 at 11 57 29 AM" src="https://github.com/consolelabs/mochi-discord/assets/39359294/8c0ed145-e012-4e3e-91af-a81be97c3363">

