### PR TITLE
chore: add space in profile cmd

### DIFF
--- a/src/commands/profile/index/processor.ts
+++ b/src/commands/profile/index/processor.ts
@@ -208,6 +208,7 @@ async function compose(
             }/${nextLevelMinXp}\``,
           ]
         : []),
+      "",
       `**Wallets**`,
       await renderWallets({
         mochiWallets: {


### PR DESCRIPTION
**What does this PR do?**

-   [x] Add spacing in profile command (Wallets)

**How to test**
`/profile`

**Media (Loom or gif)**
<img width="221" alt="CleanShot 2023-07-31 at 17 41 02@2x" src="https://github.com/consolelabs/mochi-discord/assets/25856620/911de632-2a96-4810-81f4-6f83b7821bb3">

