### PR TITLE
fix: vault transfer address

### DIFF
--- a/src/commands/vault/transfer/processor.ts
+++ b/src/commands/vault/transfer/processor.ts
@@ -48,7 +48,10 @@ export async function runTransferTreasurer({
     return
   }
 
-  const userProfileId = await getProfileIdByDiscord(user?.id ?? "")
+  let userProfileId = ""
+  if (user) {
+    userProfileId = await getProfileIdByDiscord(user.id)
+  }
   const requesterProfileId = await getProfileIdByDiscord(i.user.id)
 
   const vaultName = i.options.getString("name", true)

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -328,17 +328,6 @@ export interface ModelOffchainTipBotToken {
   updated_at?: string
 }
 
-export interface ModelProductBotCommand {
-  code?: string
-  created_at?: string
-  description?: string
-  discord_command?: string
-  id?: number
-  scope?: number
-  telegram_command?: string
-  updated_at?: string
-}
-
 export interface ModelProductMetadataEmojis {
   code?: string
   discord_id?: string
@@ -794,7 +783,6 @@ export interface RequestTransferV2Request {
   recipients?: string[]
   sender?: string
   token?: string
-  transfer_type?: "transfer" | "airdrop"
 }
 
 export interface RequestUnlinkBinance {
@@ -1914,6 +1902,10 @@ export interface ResponseNftWatchlistSuggestResponse {
 
 export interface ResponseOffchainTipBotTransferToken {
   amount_each?: number
+  /**
+   * SenderID    string  `json:"sender_id"`
+   * Recipients  string  `json:"recipient_id"`
+   */
   id?: string
   total_amount?: number
   tx_id?: number
@@ -1937,10 +1929,6 @@ export interface ResponsePaginationResponse {
   /** page size */
   size?: number
   total?: number
-}
-
-export interface ResponseProductBotCommand {
-  data?: ModelProductBotCommand[]
 }
 
 export interface ResponseProfileAirdropCampaignResponse {
@@ -2114,7 +2102,10 @@ export interface ResponseTopUser {
 
 export interface ResponseTransferTokenV2Data {
   amount_each?: number
-  external_id?: string
+  /**
+   * SenderID    string  `json:"sender_id"`
+   * Recipients  string  `json:"recipient_id"`
+   */
   id?: string
   total_amount?: number
   tx_id?: number


### PR DESCRIPTION
**What does this PR do?**
-   [x] /vault transfer address: handle empty user's profile ID properly