### PR TITLE
fix: domain validation before resolving

### DIFF
--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -827,6 +827,7 @@ export interface RequestTransferV2Request {
   amount?: number
   chain_id?: string
   channel_id?: string
+  channel_name?: string
   each?: boolean
   guild_id?: string
   message?: string
@@ -1243,18 +1244,19 @@ export interface ResponseFindTokenByContractAddressResponse {
 
 export interface ResponseFriendTechKey {
   address?: string
-  createdAt?: string
+  created_at?: string
   holders?: number
   id?: number
   price?: number
-  profileChecked?: boolean
+  price_change_percentage?: number
+  profile_checked?: boolean
   supply?: number
-  twitterPfpUrl?: string
-  twitterUsername?: string
-  updatedAt?: string
+  twitter_pfp_url?: string
+  twitter_username?: string
+  updated_at?: string
 }
 
-export interface ResponseFriendTechKeyWatchlistItemRespose {
+export interface ResponseFriendTechKeyWatchlistItemResponse {
   created_at?: string
   decrease_alert_at?: number
   id?: number
@@ -2267,7 +2269,7 @@ export interface ResponseTopUser {
 }
 
 export interface ResponseTrackFriendTechKeyResponse {
-  data?: ResponseFriendTechKeyWatchlistItemRespose
+  data?: ResponseFriendTechKeyWatchlistItemResponse
 }
 
 export interface ResponseTransferTokenV2Data {

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -893,6 +893,7 @@ CacheManager.init({
   checkperiod: 604800,
 })
 export async function resolveNamingServiceDomain(domain: string) {
+  if (!domain) return domain
   return await CacheManager.get({
     pool: "naming-service",
     key: domain,


### PR DESCRIPTION
**What does this PR do?**
- [x] Validate domain before resolving it (empty, null, etc.): avoid redundant querying time