### PR TITLE
fix: handle case same contract hash at different chains

### DIFF
--- a/src/commands/deposit/index/processor.ts
+++ b/src/commands/deposit/index/processor.ts
@@ -7,6 +7,7 @@ import {
   SelectMenuInteraction,
 } from "discord.js"
 import { APIError, InternalError } from "errors"
+import qrcode from "qrcode"
 import { composeEmbedMessage, formatDataTable } from "ui/discord/embed"
 import {
   emojis,
@@ -16,9 +17,9 @@ import {
   getEmojiURL,
   TokenEmojiKey,
 } from "utils/common"
+
 import mochiPay from "../../../adapters/mochi-pay"
 import { getProfileIdByDiscord } from "../../../utils/profile"
-import qrcode from "qrcode"
 
 export async function deposit(
   interaction: CommandInteraction | ButtonInteraction,
@@ -61,7 +62,7 @@ export async function deposit(
     address: string
     symbol: string
   }> = Array.from<any>(
-    new Map(addressesDup.map((a: any) => [a.contract.address, a])).values(),
+    new Map(addressesDup.map((a: any) => [a.contract.id, a])).values(),
   ).map((a) => ({
     symbol: a.contract.chain.symbol.toUpperCase(),
     address: a.contract.address,
@@ -156,7 +157,7 @@ export function renderListDepositAddress({
             custom_id: "VIEW_DEPOSIT_ADDRESS",
             options: addresses.map((a) => ({
               label: a.address,
-              value: a.address,
+              value: a.symbol + "." + a.address,
               emoji: getEmojiToken(a.symbol as TokenEmojiKey),
             })),
           }),

--- a/src/commands/deposit/index/slash.ts
+++ b/src/commands/deposit/index/slash.ts
@@ -8,6 +8,7 @@ import {
 } from "discord.js"
 import { equalIgnoreCase } from "utils/common"
 import { MachineConfig, route } from "utils/router"
+
 import * as processor from "./processor"
 
 export const machineConfig: (
@@ -60,12 +61,14 @@ export const machineConfig: (
     },
     select: {
       depositDetail: async (i, _ev, ctx) => {
+        const values = i.values.map((v) => v.split(".")[1])
+
         return {
           msgOpts: await processor.depositDetail(
             i,
             amount,
             ctx.addresses.find((a: any) =>
-              equalIgnoreCase(a.address, i.values.at(0)),
+              equalIgnoreCase(a.address, values.at(0)),
             ),
           ),
         }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -328,39 +328,6 @@ export interface ModelOffchainTipBotToken {
   updated_at?: string
 }
 
-export interface ModelProductBotCommand {
-  code?: string
-  created_at?: string
-  description?: string
-  discord_alias?: string
-  discord_command?: string
-  id?: number
-  scope?: number
-  telegram_alias?: string
-  telegram_command?: string
-  updated_at?: string
-}
-
-export interface ModelProductChangelogView {
-  changelog_name?: string
-  created_at?: string
-  key?: string
-  metadata?: number[]
-  updated_at?: string
-}
-
-export interface ModelProductChangelogs {
-  content?: string
-  created_at?: string
-  file_name?: string
-  github_url?: string
-  is_expired?: boolean
-  product?: string
-  thumbnail_url?: string
-  title?: string
-  updated_at?: string
-}
-
 export interface ModelProductMetadataEmojis {
   code?: string
   discord_id?: string
@@ -647,11 +614,6 @@ export interface RequestCreateNFTCollectionRequest {
   priority_flag?: boolean
 }
 
-export interface RequestCreateProductChangelogsViewRequest {
-  changelog_name?: string
-  key?: string
-}
-
 export interface RequestCreateProfileAirdropCampaignRequest {
   airdrop_campaign_id?: number
   is_favorite?: boolean
@@ -771,11 +733,6 @@ export interface RequestOffchainTransferRequest {
   transfer_type?: string
 }
 
-export interface RequestOnboardingStartRequest {
-  platform: "discord" | "telegram"
-  profile_id: string
-}
-
 export interface RequestRoleReactionRequest {
   guild_id?: string
   message_id?: string
@@ -805,13 +762,6 @@ export interface RequestSwapRequest {
   userDiscordId: string
 }
 
-export interface RequestTrackFriendTechKeyRequest {
-  decrease_alert_at?: number
-  increase_alert_at?: number
-  key_address: string
-  profile_id: string
-}
-
 export interface RequestTrackWalletRequest {
   address: string
   alias?: string
@@ -832,14 +782,10 @@ export interface RequestTransferV2Request {
   guild_id?: string
   message?: string
   metadata?: Record<string, any>
-  moniker?: string
-  original_amount?: number
-  original_tx_id?: string
   platform?: string
   recipients?: string[]
   sender?: string
   token?: string
-  transfer_type?: "transfer" | "airdrop"
 }
 
 export interface RequestUnlinkBinance {
@@ -849,11 +795,6 @@ export interface RequestUnlinkBinance {
 export interface RequestUpdateDaoVoteRequest {
   choice: string
   user_id: string
-}
-
-export interface RequestUpdateFriendTechKeyTrackRequest {
-  decrease_alert_at?: number
-  increase_alert_at?: number
 }
 
 export interface RequestUpdateGuildRequest {
@@ -1133,10 +1074,6 @@ export interface ResponseCreateNFTCollectionResponse {
   data?: ModelNFTCollection
 }
 
-export interface ResponseCreateProductChangelogsViewed {
-  data?: ModelProductChangelogView
-}
-
 export interface ResponseCreateProposalChannelConfigResponse {
   data?: ModelGuildConfigDaoProposal
 }
@@ -1174,42 +1111,6 @@ export interface ResponseDefaultRole {
 
 export interface ResponseDefaultRoleResponse {
   data?: ResponseDefaultRole
-}
-
-export interface ResponseDexPair {
-  address?: string
-  base_token?: ResponseDexToken
-  chain_id?: string
-  created_at?: number
-  dex_id?: string
-  fdv?: number
-  holders?: ResponseDexTokenHolder[]
-  id?: string
-  liquidity_usd?: number
-  market_cap_usd?: number
-  name?: string
-  owner?: string
-  price?: number
-  price_percent_change_24h?: number
-  price_usd?: number
-  quote_token?: ResponseDexToken
-  txn_24h_buy?: number
-  txn_24h_sell?: number
-  url?: Record<string, string>
-  volume_usd_24h?: number
-}
-
-export interface ResponseDexToken {
-  address?: string
-  name?: string
-  symbol?: string
-}
-
-export interface ResponseDexTokenHolder {
-  address?: string
-  alias?: string
-  balance?: number
-  percent?: number
 }
 
 export interface ResponseDiscordGuildResponse {
@@ -1510,10 +1411,6 @@ export interface ResponseGetOneWalletResponse {
   data?: ModelUserWalletWatchlistItem
 }
 
-export interface ResponseGetProductChangelogsViewed {
-  data?: ModelProductChangelogView[]
-}
-
 export interface ResponseGetSalesTrackerConfigResponse {
   data?: ModelGuildConfigSalesTracker[]
 }
@@ -1591,10 +1488,6 @@ export interface ResponseGetUserQuestListResponse {
 
 export interface ResponseGetUserResponse {
   data?: ResponseUser
-}
-
-export interface ResponseGetVaultResponse {
-  data?: ModelVault
 }
 
 export interface ResponseGetVaultsResponse {
@@ -2047,6 +1940,11 @@ export interface ResponseNftWatchlistSuggestResponse {
 
 export interface ResponseOffchainTipBotTransferToken {
   amount_each?: number
+
+  /**
+   * SenderID    string  `json:"sender_id"`
+   * Recipients  string  `json:"recipient_id"`
+   */
   id?: string
   total_amount?: number
   tx_id?: number
@@ -2054,20 +1952,6 @@ export interface ResponseOffchainTipBotTransferToken {
 
 export interface ResponseOffchainTipBotTransferTokenResponse {
   data?: ResponseOffchainTipBotTransferToken[]
-}
-
-export interface ResponseOnboardingStartData {
-  reward?: ResponseOnboardingStartReward
-  user_already_started?: boolean
-}
-
-export interface ResponseOnboardingStartResponse {
-  data?: ResponseOnboardingStartData
-}
-
-export interface ResponseOnboardingStartReward {
-  amount?: string
-  token?: string
 }
 
 export interface ResponseOnchainInvestData {
@@ -2085,14 +1969,6 @@ export interface ResponsePaginationResponse {
   /** page size */
   size?: number
   total?: number
-}
-
-export interface ResponseProductBotCommand {
-  data?: ModelProductBotCommand[]
-}
-
-export interface ResponseProductChangelogs {
-  data?: ModelProductChangelogs[]
 }
 
 export interface ResponseProfileAirdropCampaignResponse {
@@ -2168,10 +2044,6 @@ export interface ResponseRouteToken {
 
 export interface ResponseSearchCoinResponse {
   data?: ModelCoingeckoSupportedTokens[]
-}
-
-export interface ResponseSearchDexPairResponse {
-  pairs?: ResponseDexPair[]
 }
 
 export interface ResponseSparkLineIn7D {
@@ -2274,7 +2146,11 @@ export interface ResponseTrackFriendTechKeyResponse {
 
 export interface ResponseTransferTokenV2Data {
   amount_each?: number
-  external_id?: string
+
+  /**
+   * SenderID    string  `json:"sender_id"`
+   * Recipients  string  `json:"recipient_id"`
+   */
   id?: string
   total_amount?: number
   tx_id?: number


### PR DESCRIPTION
**What does this PR do?**

Different chains with the same deposit contract hash let missing options when choosing contract to deposit

![image](https://github.com/consolelabs/mochi-discord/assets/32956772/03cb2477-b2ed-46ee-ac00-89e29696c70f)
