### PR TITLE
fix: replace is evm by chain type

### DIFF
--- a/src/commands/balances/index/processor.test.ts
+++ b/src/commands/balances/index/processor.test.ts
@@ -1,8 +1,10 @@
 import profile from "adapters/profile"
 import { CommandInteraction } from "discord.js"
 import { composeEmbedMessage, justifyEmbedFields } from "ui/discord/embed"
+import { chainTypes } from "utils/chain"
 import { getSlashCommand } from "utils/commands"
 import { emojis, getEmoji, getEmojiURL } from "utils/common"
+
 import mockdc from "../../../../tests/mocks/discord"
 import mochiPay from "../../../adapters/mochi-pay"
 import { BalanceType, renderBalances } from "./processor"
@@ -40,7 +42,7 @@ describe("balances", () => {
         rpc: "https://polygon.llamarpc.com",
         explorer: "https://polygonscan.com",
         icon: "https://cdn.discordapp.com/emojis/928216430535671818.png?size=240&quality=lossless",
-        is_evm: true,
+        type: chainTypes.EVM,
       },
     },
     other_profile: null,

--- a/src/commands/deposit/index/processor.ts
+++ b/src/commands/deposit/index/processor.ts
@@ -9,6 +9,7 @@ import {
 import { APIError, InternalError } from "errors"
 import qrcode from "qrcode"
 import { composeEmbedMessage, formatDataTable } from "ui/discord/embed"
+import { isEvm } from "utils/chain"
 import {
   emojis,
   getAuthor,
@@ -69,7 +70,7 @@ export async function deposit(
     decimal: a.token.decimal,
     chainId: Number(a.token.chain_id ?? 1),
     tokenAddress: a.token.address,
-    isEVM: a.contract.chain.is_evm,
+    chainType: a.contract.chain.type,
     isNative: a.token.native,
     explorer: a.contract.chain.explorer,
   }))
@@ -102,7 +103,7 @@ export function renderListDepositAddress({
     }
 
   const dataRows = addresses.map((a) => {
-    const link = a.isEVM
+    const link = isEvm(a.chainType)
       ? toMetamaskDeeplink(
           a.address,
           amount,
@@ -201,7 +202,7 @@ export async function depositDetail(
 ) {
   let link
   // create QR code image
-  if (depositObj.isEVM) {
+  if (isEvm(depositObj.chainType)) {
     link = toMetamaskDeeplink(
       i.values.at(0) ?? "",
       amount,
@@ -225,7 +226,7 @@ export async function depositDetail(
         "ANIMATED_POINTING_RIGHT",
         true,
       )} Transactions take up to 5 minutes to process.`,
-      ...(depositObj.isEVM
+      ...(isEvm(depositObj.chainType)
         ? [`${getEmoji("METAMASK")} Scan QR to auto-fill in Metamask.`]
         : []),
       getEmoji("LINE").repeat(5),

--- a/src/commands/pay/me/processor.ts
+++ b/src/commands/pay/me/processor.ts
@@ -1,38 +1,39 @@
 import mochiPay from "adapters/mochi-pay"
 import profile from "adapters/profile"
-import { utils } from "@consolelabs/mochi-ui"
 import { CommandInteraction } from "discord.js"
 import { APIError, InternalError, OriginalMessage } from "errors"
-import { composeEmbedMessage } from "ui/discord/embed"
 import { UnsupportedTokenError } from "errors/unsupported-token"
-import { isTokenSupported, parseMoniker } from "utils/tip-bot"
+import { parseUnits } from "ethers/lib/utils"
 import { embedsColors } from "types/common"
 import { composeButtonLink } from "ui/discord/button"
-
+import { composeEmbedMessage } from "ui/discord/embed"
+import { isEvm } from "utils/chain"
 import {
-  TokenEmojiKey,
   emojis,
   equalIgnoreCase,
   getAuthor,
   getEmoji,
   getEmojiToken,
   getEmojiURL,
+  TokenEmojiKey,
 } from "utils/common"
 import {
   MOCHI_ACTION_PAY_ME,
   MOCHI_PLATFORM_DISCORD,
-  PREFIX_EMAIL_HANDLER,
   PREFIX_DISCORD_HANDLER,
+  PREFIX_EMAIL_HANDLER,
   PREFIX_TELEGRAM_HANDLER,
   SPACES_REGEX,
 } from "utils/constants"
 import { reply } from "utils/discord"
 import { sendNotificationMsg } from "utils/kafka"
-import { dmUser } from "../../../utils/dm"
-import { parseUnits } from "ethers/lib/utils"
-import { getToken } from "../../../utils/tip-bot"
+import { isTokenSupported, parseMoniker } from "utils/tip-bot"
+
+import { utils } from "@consolelabs/mochi-ui"
+
 import { parseDiscordToken } from "../../../utils/commands"
-import { Message } from "@solana/web3.js"
+import { dmUser } from "../../../utils/dm"
+import { getToken } from "../../../utils/tip-bot"
 
 const typePayRequest = 16
 export async function run({
@@ -70,7 +71,7 @@ export async function run({
   if (!mochiWalletResOk) throw new Error()
   inAppWallets ||= []
   inAppWallets = inAppWallets.filter((w: any) => {
-    if (t?.chain?.is_evm) {
+    if (t?.chain?.type && isEvm(t?.chain?.type)) {
       return equalIgnoreCase(w.chain.symbol, "evm")
     }
     return equalIgnoreCase(w.chain.symbol, t?.chain?.symbol ?? "")
@@ -96,7 +97,7 @@ export async function run({
         }
       })
       .filter((w: any) => {
-        if (t?.chain?.is_evm) {
+        if (t?.chain?.type && isEvm(t?.chain?.type)) {
           return equalIgnoreCase(w.chain.symbol, "evm")
         }
         return equalIgnoreCase(w.chain.symbol, t?.chain?.symbol ?? "")

--- a/src/commands/vault/info/slash.ts
+++ b/src/commands/vault/info/slash.ts
@@ -1,16 +1,19 @@
-import { CommandInteraction, Message } from "discord.js"
-import { SlashCommandSubcommandBuilder } from "@discordjs/builders"
-import { composeEmbedMessage } from "ui/discord/embed"
-import { GM_GITBOOK, SLASH_PREFIX } from "utils/constants"
-import { SlashCommand } from "types/common"
-import { runGetVaultDetail } from "./processor"
 import config from "adapters/config"
-import { MachineConfig, route } from "utils/router"
 import {
-  renderListDepositAddress,
   depositDetail,
+  renderListDepositAddress,
 } from "commands/deposit/index/processor"
+import { CommandInteraction, Message } from "discord.js"
+import { SlashCommand } from "types/common"
+import { composeEmbedMessage } from "ui/discord/embed"
+import { chainTypes } from "utils/chain"
 import { equalIgnoreCase } from "utils/common"
+import { GM_GITBOOK, SLASH_PREFIX } from "utils/constants"
+import { MachineConfig, route } from "utils/router"
+
+import { SlashCommandSubcommandBuilder } from "@discordjs/builders"
+
+import { runGetVaultDetail } from "./processor"
 
 const machineConfig: MachineConfig = {
   id: "vault-info",
@@ -89,7 +92,7 @@ const command: SlashCommand = {
               address: context.deposit.evm,
               decimal: 18,
               chainId: 1,
-              isEVM: true,
+              chainType: chainTypes.EVM,
               isNative: true,
             },
             {
@@ -97,7 +100,7 @@ const command: SlashCommand = {
               address: context.deposit.sol,
               decimal: 18,
               chainId: 1,
-              isEVM: false,
+              chainType: chainTypes.SOL,
               isNative: true,
             },
           ]

--- a/src/utils/chain.ts
+++ b/src/utils/chain.ts
@@ -1,0 +1,28 @@
+export function isEvm(chainType: string): boolean {
+  return chainType === chainTypes.EVM
+}
+
+export function isSolana(chainType: string): boolean {
+  return chainType === chainTypes.SOL
+}
+
+export function isTon(chainType: string): boolean {
+  return chainType === chainTypes.TON
+}
+
+export function isBitcoin(chainType: string): boolean {
+  return chainType === chainTypes.BTC
+}
+
+export function isRonin(chainType: string): boolean {
+  return chainType === chainTypes.RON
+}
+
+// TODO: check other locations where change type is defined, replace by this
+export const chainTypes = {
+  EVM: "evm",
+  SOL: "solana",
+  TON: "ton",
+  BTC: "bitcoin",
+  RON: "ronin",
+}


### PR DESCRIPTION
**What does this PR do?**

Change from using isEvm to chainType, to be compatible with change of following migrations:
- https://github.com/consolelabs/mochi-pay-api/pull/334
- https://github.com/consolelabs/mochi-pay-api/pull/338