### PR TITLE
fix(sentry): handle read-only error

### DIFF
--- a/src/utils/wrap-error.ts
+++ b/src/utils/wrap-error.ts
@@ -60,7 +60,12 @@ export async function wrapError(
     }
 
     // prepend product name and command name
-    e.name = `${PRODUCT_NAME}: ${commandStr} ⎯  ${e.name}`
+    try {
+      e.name = `${PRODUCT_NAME}: ${commandStr} ⎯  ${e.name}`
+    } catch {
+      // Sometimes the name property is read-only
+      cc.extra.error = { readonly: true }
+    }
 
     // calling api failed, with status code 500, send to sentry
     if (e instanceof APIError && e.status === 500) {


### PR DESCRIPTION
**What does this PR do?**

-   [x] error name prop can be readonly sometime, just ignore and give more context to sentry when this happen
