### PR TITLE
fix: support diff format tip and keep the follow up msg

### DIFF
--- a/src/commands/tip/index/processor.ts
+++ b/src/commands/tip/index/processor.ts
@@ -439,7 +439,7 @@ export async function handleFollowTip(i: ButtonInteraction) {
         newAmount,
       )} **${payload.token.toUpperCase()}** ${amountApprox}
       \`Receiver.  \` ${payload.targets.join(", ")}
-      \`Message.   \` Send money.
+      \`Message.   \` ${payload.message || "Send money"}
     `,
     color: "#89fa8e",
   })
@@ -528,7 +528,7 @@ export async function handleConfirmFollowTip(i: ButtonInteraction) {
     amount: parseFloat(amountStr),
     token: followTx.token.symbol,
     transfer_type: followTx.action,
-    message: "Send money",
+    message: followTx.message || "Send money",
     chain_id: followTx.token.chain_id,
     platform: "discord",
     original_amount: followTx.metadata.original_amount,

--- a/src/commands/tip/index/text.ts
+++ b/src/commands/tip/index/text.ts
@@ -1,6 +1,7 @@
 import { Message } from "discord.js"
 import { getCommandArguments } from "utils/commands"
 import { tip } from "./processor"
+import { equalIgnoreCase } from "utils/common"
 
 const run = async (msg: Message) => {
   const args = getCommandArguments(msg)

--- a/src/utils/tip-bot.ts
+++ b/src/utils/tip-bot.ts
@@ -306,6 +306,18 @@ export function getTargets(args: string[]): {
     lastIdx: -1,
     valid: false,
   }
+  let amountUnit: string[] = []
+  const amountUnitNoSpaceRegEx = /^((?:\d+(?:[.,]\d+)*)|\d*[.,]\d+)(\D+)$/i
+  if (
+    /^\d+(,\d+)?(\.\d+)?$/.test(args[1]) ||
+    equalIgnoreCase(args[1], "all") ||
+    equalIgnoreCase(args[1], "a") ||
+    equalIgnoreCase(args[1], "an")
+  ) {
+    amountUnit = args.splice(1, 2)
+  } else if (amountUnitNoSpaceRegEx.test(args[1])) {
+    amountUnit = args.splice(1, 1)
+  }
 
   const content = args.join(SPACE)
   for (const [idx, a] of args.entries()) {
@@ -339,6 +351,10 @@ export function getTargets(args: string[]): {
 
   // if first target is not placed in 2nd position -> incorrect syntax
   if (result.firstIdx !== 1) result.valid = false
+
+  if (amountUnit) {
+    args.splice(result.lastIdx + 1, 0, ...amountUnit)
+  }
   return result
 }
 
@@ -416,6 +432,9 @@ export function parseTipAmount(
   msgOrInteraction: Message | CommandInteraction,
   amountArg: string,
 ): { all: boolean; amount: number; unit?: string } {
+  // replace "," to "." in amount
+  amountArg = amountArg.replace(",", ".")
+
   if (amountArg.startsWith(".")) {
     amountArg = `0${amountArg}`
   }


### PR DESCRIPTION
**What does this PR do?**

-   support diff format tip: /tip <users> <amount> or /tip <amount> <users>
-  keep the follow up msg as it is
-  fix bug for float with "," make the amount wrong
<img width="663" alt="Screenshot 2024-02-20 at 13 44 25" src="https://github.com/consolelabs/mochi-discord/assets/28944972/bd3b6a97-617b-4da9-9970-80eac420d908">
<img width="853" alt="Screenshot 2024-02-20 at 15 45 14" src="https://github.com/consolelabs/mochi-discord/assets/28944972/80681930-97d5-4e4c-ba9e-1b64bfda8719">


