### PR TITLE
fix: track token - adjust payload

### DIFF
--- a/src/commands/watchlist/add/processor.ts
+++ b/src/commands/watchlist/add/processor.ts
@@ -68,7 +68,7 @@ export async function addToWatchlistFromTicker(
   const data = await addUserWatchlist(
     msg,
     userId,
-    to.toLowerCase(),
+    baseCoin.symbol.toLowerCase(),
     baseCoin.id,
   )
   if (!data) return null


### PR DESCRIPTION
**What does this PR do?**
Add token to watchlist from ticker: update payload data
- Current: pass coin ID to `symbol`
- Solution: use correct symbol in the request payload