### PR TITLE
fix: ticker chart - y-axis number format

### DIFF
--- a/src/ui/canvas/chart.ts
+++ b/src/ui/canvas/chart.ts
@@ -51,8 +51,10 @@ export async function renderChartImage({
         size: 16,
       },
       color: colorConfig.borderColor,
-      callback: (value: string | number) =>
-        utils.formatDigit({ value, subscript: true }),
+      callback: (value: string | number) => {
+        const n = Number(String(value).replaceAll(",", "")).toFixed(4)
+        return utils.formatDigit({ value: n, subscript: true })
+      },
     },
     grid: {
       borderColor: colorConfig.borderColor,


### PR DESCRIPTION
**What does this PR do?**
- Ticker chart: fix y-axis number format
Reason: Seems like there is a bug from `chartjs` - when we try to overwrite the default y-axis value format configuration option (`ticks.callback`),  integers will somehow unnecessarily get extra zero decimals (e.g. 3-> 3.0000000000000004)