### PR TITLE
fix(vault): add chart pnl for trading vault

### DIFF
--- a/src/adapters/mochi-pay.ts
+++ b/src/adapters/mochi-pay.ts
@@ -386,6 +386,22 @@ class MochiPay extends Fetcher {
     }
     return data
   }
+
+  async getInvestorPnls(
+    profileId: string,
+    vaultId: string,
+    query?: { trade_set_id: string },
+  ): Promise<any> {
+    const { ok, data: res } = await this.jsonFetch(
+      `${MOCHI_PAY_API_BASE_URL}/profiles/${profileId}/syndicates/earning-vaults/${vaultId}/pnl`,
+      { query },
+    )
+    let data = null
+    if (ok) {
+      data = res as any
+    }
+    return data
+  }
 }
 
 export default new MochiPay()

--- a/src/utils/chart.ts
+++ b/src/utils/chart.ts
@@ -1,0 +1,80 @@
+import { createCanvas } from "canvas"
+import { ChartJSNodeCanvas } from "chartjs-node-canvas"
+
+function getGradientColor(fromColor: string, toColor: string) {
+  const canvas = createCanvas(100, 100)
+  const ctx = canvas.getContext("2d")
+  const gradient = ctx.createLinearGradient(0, 0, 0, 400)
+  gradient.addColorStop(0, fromColor)
+  gradient.addColorStop(1, toColor)
+  return gradient
+}
+
+export async function drawLineChart({
+  title,
+  labels,
+  data,
+}: {
+  title?: string
+  labels: string[]
+  data: number[]
+}) {
+  const borderColor = "#009cdb"
+  const backgroundColor = getGradientColor(
+    "rgba(53,83,192,0.9)",
+    "rgba(58,69,110,0.5)",
+  )
+  const chartCanvas = new ChartJSNodeCanvas({
+    width: 700,
+    height: 450,
+    backgroundColour: "#202020",
+  })
+  const axisConfig = {
+    ticks: {
+      font: { size: 16 },
+      color: borderColor,
+    },
+    grid: {
+      color: "rgba(0,0,0,0.2)",
+      borderWidth: 1,
+      borderColor: borderColor,
+    },
+  }
+  return chartCanvas.renderToBuffer({
+    type: "line",
+    data: {
+      labels,
+      datasets: [
+        {
+          label: title,
+          data,
+          borderWidth: 2,
+          pointRadius: 0,
+          fill: true,
+          borderColor,
+          backgroundColor,
+          tension: 0.5,
+        },
+      ],
+    },
+    options: {
+      layout: {
+        padding: { left: 15, bottom: 15, top: 15, right: 15 },
+      },
+      scales: {
+        y: axisConfig,
+        x: axisConfig,
+      },
+      plugins: {
+        legend: {
+          labels: {
+            // This more specific font property overrides the global property
+            font: {
+              size: 18,
+            },
+          },
+        },
+      },
+    },
+  })
+}


### PR DESCRIPTION
**What does this PR do?**

-   [x] add render pnl chart when show trading vault info
<img width="542" alt="Screenshot 2024-06-19 at 11 13 48" src="https://github.com/consolelabs/mochi-discord/assets/28944972/ab186060-2b3d-4550-accc-7d807bbad63c">
